### PR TITLE
fix: 休憩テーブル名をbreaksに変更

### DIFF
--- a/database/migrations/2026_08_12_042408_create_breaks_table.php
+++ b/database/migrations/2026_08_12_042408_create_breaks_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('attendance_breaks', function (Blueprint $table) {
+        Schema::create('breaks', function (Blueprint $table) {
             $table->id();
             $table->foreignId('attendance_record_id')
                 ->constrained('attendance_records')
@@ -27,6 +27,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('attendance_breaks');
+        Schema::dropIfExists('breaks');
     }
 };


### PR DESCRIPTION
## 概要

仕様書に合わせて、休憩情報を保存するテーブル名を`attendance_breaks` から `breaks` に変更しました。

## 変更内容

- `attendance_breaks` テーブルを `breaks` テーブルに変更

## 確認内容

- `sail artisan migrate:fresh` が正常に実行できることを確認
- phpMyAdminで `breaks` テーブルが作成されることを確認
- `attendance_breaks` テーブルが作成されないことを確認