### PR TITLE
feat: モデル・リレーション・Seeder実装 #2

### DIFF
--- a/app/Models/AttendanceBreak.php
+++ b/app/Models/AttendanceBreak.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AttendanceBreak extends Model
+{
+    use HasFactory;
+
+    protected $table = 'breaks';
+
+    protected $fillable = [
+        'attendance_record_id',
+        'break_in',
+        'break_out',
+    ];
+
+    // attendance_record_idを外部キーとしてAttendanceRecordモデルとのリレーションを定義
+    public function attendanceRecord(): BelongsTo
+    {
+        return $this->belongsTo(AttendanceRecord::class);
+    }
+}

--- a/app/Models/AttendanceCorrectionRequest.php
+++ b/app/Models/AttendanceCorrectionRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AttendanceCorrectionRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'attendance_record_id',
+        'approval_status',
+        'comment',
+        'new_date',
+        'new_clock_in',
+        'new_clock_out',
+    ];
+
+    // user_idを外部キーとしてUserモデルとのリレーションを定義
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    // attendance_record_idを外部キーとしてAttendanceRecordモデルとのリレーションを定義
+    public function attendanceRecord(): BelongsTo
+    {
+        return $this->belongsTo(AttendanceRecord::class);
+    }
+
+    // 修正申請に紐づく申請休憩情報とのリレーションを定義
+    public function proposalBreaks(): HasMany
+    {
+        return $this->hasMany(ProposalBreak::class);
+    }
+}

--- a/app/Models/AttendanceRecord.php
+++ b/app/Models/AttendanceRecord.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AttendanceRecord extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'date',
+        'clock_in',
+        'clock_out',
+        'comment',
+    ];
+
+    // user_idを外部キーとしてUserモデルとのリレーションを定義
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    // attendance_record_idを外部キーとしてBreakモデルとのリレーションを定義
+    public function breaks(): HasMany
+    {
+        return $this->hasMany(AttendanceBreak::class);
+    }
+
+    // attendance_record_idを外部キーとしてAttendanceCorrectionRequestモデルとのリレーションを定義
+    public function correctionRequests(): HasMany
+    {
+        return $this->hasMany(AttendanceCorrectionRequest::class);
+    }
+}

--- a/app/Models/ProposalBreak.php
+++ b/app/Models/ProposalBreak.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProposalBreak extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'attendance_correction_request_id',
+        'break_in',
+        'break_out',
+    ];
+
+    // attendance_correction_request_idを外部キーとして
+    // AttendanceCorrectionRequestモデルとのリレーションを定義
+    public function attendanceCorrectionRequest(): BelongsTo
+    {
+        return $this->belongsTo(AttendanceCorrectionRequest::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -21,6 +22,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'admin_status',
     ];
 
     /**
@@ -41,5 +43,18 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
+        'admin_status' => 'boolean',
     ];
+
+    // user_idを外部キーとしてAttendanceRecordモデルとのリレーションを定義
+    public function attendanceRecords(): HasMany
+    {
+        return $this->hasMany(AttendanceRecord::class);
+    }
+
+    // user_idを外部キーとしてAttendanceCorrectionRequestモデルとのリレーションを定義
+    public function attendanceCorrectionRequests(): HasMany
+    {
+        return $this->hasMany(AttendanceCorrectionRequest::class);
+    }
 }

--- a/database/factories/AttendanceBreakFactory.php
+++ b/database/factories/AttendanceBreakFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AttendanceBreak;
+use App\Models\AttendanceRecord;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AttendanceBreak>
+ */
+class AttendanceBreakFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'attendance_record_id' => AttendanceRecord::factory(),
+            'break_in' => '12:00:00',
+            'break_out' => '13:00:00',
+        ];
+    }
+}

--- a/database/factories/AttendanceCorrectionRequestFactory.php
+++ b/database/factories/AttendanceCorrectionRequestFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AttendanceCorrectionRequest>
+ */
+class AttendanceCorrectionRequestFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'attendance_record_id' => AttendanceRecord::factory(),
+            'approval_status' => 0,
+            'comment' => fake()->sentence(),
+            'new_date' => fake()->date(),
+            'new_clock_in' => '09:30:00',
+            'new_clock_out' => '18:00:00',
+        ];
+    }
+}

--- a/database/factories/AttendanceRecordFactory.php
+++ b/database/factories/AttendanceRecordFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AttendanceRecord>
+ */
+class AttendanceRecordFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'date' => fake()->date(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+            'comment' => fake()->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/ProposalBreakFactory.php
+++ b/database/factories/ProposalBreakFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\ProposalBreak;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProposalBreak>
+ */
+class ProposalBreakFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'attendance_correction_request_id' => AttendanceCorrectionRequest::factory(),
+            'break_in' => '12:00:00',
+            'break_out' => '13:00:00',
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -30,6 +30,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'admin_status' => false,
         ];
     }
 

--- a/database/seeders/AttendanceBreakSeeder.php
+++ b/database/seeders/AttendanceBreakSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\AttendanceBreak;
+use App\Models\AttendanceRecord;
+use Illuminate\Database\Seeder;
+
+class AttendanceBreakSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $attendanceRecords = AttendanceRecord::all();
+
+        foreach ($attendanceRecords as $attendanceRecord) {
+            AttendanceBreak::create([
+                'attendance_record_id' => $attendanceRecord->id,
+                'break_in' => '12:00:00',
+                'break_out' => '13:00:00',
+            ]);
+        }
+    }
+}

--- a/database/seeders/AttendanceCorrectionRequestSeeder.php
+++ b/database/seeders/AttendanceCorrectionRequestSeeder.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
+use Illuminate\Database\Seeder;
+
+class AttendanceCorrectionRequestSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $attendanceRecords = AttendanceRecord::inRandomOrder()
+            ->limit(21)
+            ->get();
+
+        $requests = [
+            // 出勤時間の修正
+            [
+                'comment' => '出勤時間を修正したい',
+                'new_clock_in' => '09:30:00',
+                'new_clock_out' => null,
+            ],
+
+            // 退勤時間の修正
+            [
+                'comment' => '退勤時間を修正したい',
+                'new_clock_in' => null,
+                'new_clock_out' => '19:00:00',
+            ],
+
+            // 休憩時間の修正
+            [
+                'comment' => '休憩時間を修正したい',
+                'new_clock_in' => null,
+                'new_clock_out' => null,
+            ],
+
+            // 出勤・退勤両方の修正
+            [
+                'comment' => '出勤・退勤時間を修正したい',
+                'new_clock_in' => '09:30:00',
+                'new_clock_out' => '19:00:00',
+            ],
+
+            // 日付の修正
+            [
+                'comment' => '勤務日を修正したい',
+                'new_clock_in' => null,
+                'new_clock_out' => null,
+            ],
+
+            // 出勤＋休憩
+            [
+                'comment' => '出勤時間と休憩時間を修正したい',
+                'new_clock_in' => '09:30:00',
+                'new_clock_out' => null,
+            ],
+
+            // 退勤＋休憩
+            [
+                'comment' => '退勤時間と休憩時間を修正したい',
+                'new_clock_in' => null,
+                'new_clock_out' => '19:00:00',
+            ],
+        ];
+
+        foreach ($requests as $requestIndex => $request) {
+            for ($status = 0; $status <= 2; $status++) {
+                $attendanceRecord = $attendanceRecords[$requestIndex * 3 + $status];
+
+                AttendanceCorrectionRequest::create([
+                    'user_id' => $attendanceRecord->user_id,
+                    'attendance_record_id' => $attendanceRecord->id,
+                    'approval_status' => $status,
+                    'comment' => $request['comment'],
+                    'new_date' => $requestIndex === 4
+                        ? date('Y-m-d', strtotime($attendanceRecord->date.' +1 day'))
+                        : $attendanceRecord->date,
+                    'new_clock_in' => $request['new_clock_in']
+                        ?? $attendanceRecord->clock_in,
+                    'new_clock_out' => $request['new_clock_out']
+                        ?? $attendanceRecord->clock_out,
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/AttendanceRecordSeeder.php
+++ b/database/seeders/AttendanceRecordSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+
+class AttendanceRecordSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $users = User::all();
+
+        foreach ($users as $user) {
+            for ($i = 0; $i <= 20; $i++) {
+                $date = Carbon::now()->subDays($i);
+
+                // 土日は除外
+                if ($date->isWeekend()) {
+                    continue;
+                }
+
+                AttendanceRecord::create([
+                    'user_id' => $user->id,
+                    'date' => $date->toDateString(),
+                    'clock_in' => '09:00:00',
+                    'clock_out' => '18:00:00',
+                    'comment' => '通常勤務',
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -12,11 +11,12 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        $this->call([
+            UserSeeder::class,
+            AttendanceRecordSeeder::class,
+            AttendanceBreakSeeder::class,
+            AttendanceCorrectionRequestSeeder::class,
+            ProposalBreakSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/ProposalBreakSeeder.php
+++ b/database/seeders/ProposalBreakSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\ProposalBreak;
+use Illuminate\Database\Seeder;
+
+class ProposalBreakSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // 休憩時間を含む修正申請を取得
+        $correctionRequests = AttendanceCorrectionRequest::whereIn('comment', [
+            '休憩時間を修正したい',
+            '出勤時間と休憩時間を修正したい',
+            '退勤時間と休憩時間を修正したい',
+        ])->get();
+
+        foreach ($correctionRequests as $correctionRequest) {
+            ProposalBreak::create([
+                'attendance_correction_request_id' => $correctionRequest->id,
+                'break_in' => '12:30:00',
+                'break_out' => '13:30:00',
+            ]);
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // ユーザー１（一般）を作成
+        User::create([
+            'name' => '一般ユーザー1',
+            'email' => 'user1@example.com',
+            'password' => 'password',
+            'email_verified_at' => now(),
+            'admin_status' => false,
+        ]);
+
+        // ユーザー２（一般）を作成
+        User::create([
+            'name' => '一般ユーザー2',
+            'email' => 'user2@example.com',
+            'password' => 'password',
+            'email_verified_at' => now(),
+            'admin_status' => false,
+        ]);
+
+        // ユーザー３（管理者）を作成
+        User::create([
+            'name' => '管理者ユーザー',
+            'email' => 'user3@example.com',
+            'password' => 'password',
+            'email_verified_at' => now(),
+            'admin_status' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要

勤怠管理システムで使用するModel、Model間のリレーション、Factory、Seederを実装しました。

## 変更内容

### Model

- User Modelのリレーションを追加
- AttendanceRecord Modelを作成
- AttendanceBreak Modelを作成
- AttendanceCorrectionRequest Modelを作成
- ProposalBreak Modelを作成
- 各Model間のリレーションを定義

### Factory

- UserFactoryを作成・更新
- AttendanceRecordFactoryを作成
- AttendanceBreakFactoryを作成
- AttendanceCorrectionRequestFactoryを作成
- ProposalBreakFactoryを作成

### Seeder

- UserSeederを作成
- AttendanceRecordSeederを作成
- AttendanceBreakSeederを作成
- AttendanceCorrectionRequestSeederを作成
- ProposalBreakSeederを作成
- DatabaseSeederに各Seederを登録

### ダミーデータ

- 一般ユーザー2名、管理者ユーザー1名を作成
- 全ユーザーに勤怠記録を作成
- 各勤怠記録に休憩データを作成
- 一部の勤怠に対して修正申請を作成
- 修正申請について以下の7パターンを作成

  - 出勤時間の修正
  - 退勤時間の修正
  - 休憩時間の修正
  - 出勤・退勤時間の修正
  - 勤務日の修正
  - 出勤時間＋休憩時間の修正
  - 退勤時間＋休憩時間の修正
- 修正申請の承認状態として以下の3種類を作成

  - `0`：承認待ち
  - `1`：承認済み
  - `2`：却下
- 休憩時間の修正を含む申請にはProposalBreakを作成

## 動作確認

- `./vendor/bin/sail artisan migrate:fresh --seed` が正常終了することを確認
- usersテーブルに一般ユーザー2件、管理者ユーザー1件が登録されることを確認
- attendance_recordsテーブルに勤怠データが登録されることを確認
- attendance_breaksテーブルに休憩データが登録されることを確認
- attendance_correction_requestsテーブルに修正申請が登録されることを確認
- proposal_breaksテーブルに申請休憩データが登録されることを確認
- 修正申請がない勤怠データも存在することを確認
- `approval_status` が `0 / 1 / 2` それぞれ登録されることを確認
- Tinkerでリレーションが正常に動作することを確認

## 対応Issue

close #2
