### PR TITLE
feat: 会員登録バリデーションをFormRequestへ変更 #26

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -4,36 +4,17 @@ namespace App\Actions\Fortify;
 
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\Rule;
-use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 
 class CreateNewUser implements CreatesNewUsers
 {
-    use PasswordValidationRules;
-
     /**
-     * Validate and create a newly registered user.
+     * ユーザーを作成する
      *
-     * @param  array<string, string>  $input
-     *
-     * @throws ValidationException
+     * @param  array<string, mixed>  $input
      */
     public function create(array $input): User
     {
-        Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
-            'email' => [
-                'required',
-                'string',
-                'email',
-                'max:255',
-                Rule::unique(User::class),
-            ],
-            'password' => $this->passwordRules(),
-        ])->validate();
-
         return User::create([
             'name' => $input['name'],
             'email' => $input['email'],

--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\Fortify\CreateNewUser;
+use App\Http\Requests\RegisterRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+
+class RegisterController extends Controller
+{
+    /**
+     * 一般ユーザーを登録する
+     */
+    public function store(
+        RegisterRequest $request,
+        CreateNewUser $creator
+    ): RedirectResponse {
+        $user = $creator->create($request->validated());
+
+        Auth::login($user);
+
+        return redirect()->route('attendance.index');
+    }
+}

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class RegisterRequest extends FormRequest
+{
+    /**
+     * リクエストを許可するか
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * バリデーションルール
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+
+            'email' => [
+                'required',
+                'string',
+                'email',
+                'max:255',
+                Rule::unique(User::class),
+            ],
+
+            'password' => [
+                'required',
+                'string',
+                'min:8',
+                'max:255',
+                'confirmed',
+            ],
+        ];
+    }
+
+    /**
+     * エラーメッセージ
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'お名前を入力してください',
+            'email.required' => 'メールアドレスを入力してください',
+            'email.email' => 'メールアドレスはメール形式で入力してください',
+            'password.required' => 'パスワードを入力してください',
+            'password.min' => 'パスワードは8文字以上で入力してください',
+            'password.confirmed' => 'パスワードと一致しません',
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\RegisterController;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
@@ -19,6 +20,10 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+// 会員登録処理
+Route::post('/register', [RegisterController::class, 'store'])
+    ->name('register.store');
+
 Route::middleware('auth')->group(function () {
 
     // 仮の勤怠登録画面
@@ -37,5 +42,4 @@ Route::middleware('auth')->group(function () {
             'formattedTime'
         ));
     })->name('attendance.index');
-
 });


### PR DESCRIPTION
## 概要

Laravel Fortifyを使用した一般ユーザーの会員登録機能について、バリデーション処理をFormRequestへ変更しました。

## 変更内容

- `RegisterRequest` を作成
- 会員登録時のバリデーションをFormRequestへ移行
- バリデーションエラーメッセージを設定
- `RegisterController` を作成し、会員登録処理を実装
- `CreateNewUser` からバリデーション処理を分離
- 会員登録後にユーザーをログイン状態にする処理を実装
- 会員登録後に勤怠登録画面（`/attendance`）へ遷移する処理を実装
- `/register` のPOST処理を `RegisterController@store` に変更

## 動作確認

- [ ] 会員登録画面が正常に表示されることを確認
- [ ] 正しい入力内容で一般ユーザーを登録できることを確認
- [ ] 指定されたエラーメッセージが表示されることを確認
- [ ] 登録したユーザーが `users` テーブルに保存されることを確認
- [ ] 会員登録成功後、ユーザーがログイン状態になることを確認
- [ ] 会員登録成功後、勤怠登録画面（`/attendance`）へ遷移することを確認

## 対応Issue

Closes #26