### PR TITLE
会員登録画面をRegisterControllerで表示する #28

### DIFF
--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -6,9 +6,18 @@ use App\Actions\Fortify\CreateNewUser;
 use App\Http\Requests\RegisterRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 
 class RegisterController extends Controller
 {
+    /**
+     * 会員登録画面を表示する
+     */
+    public function create(): View
+    {
+        return view('user.register');
+    }
+
     /**
      * 一般ユーザーを登録する
      */

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,10 @@ Route::get('/', function () {
     return view('welcome');
 });
 
+// 会員登録画面
+Route::get('/register', [RegisterController::class, 'create'])
+    ->name('register');
+
 // 会員登録処理
 Route::post('/register', [RegisterController::class, 'store'])
     ->name('register.store');


### PR DESCRIPTION
## 概要

Laravel Fortifyで提供されていた会員登録画面の表示処理を、アプリケーション側の`RegisterController@create`へ変更しました。

## 変更内容

- `RegisterController@create`を実装
- `GET /register`を`RegisterController@create`へ変更
- 会員登録画面のViewに`resources/views/user/register.blade.php`を使用
- Fortifyの標準`GET /register`とのルート競合を解消
- `POST /register`の既存の会員登録処理は`RegisterController@store`のまま維持

## 動作確認

- [ ] `RegisterController@create`が実装されていることを確認
- [ ] `GET /register`が`RegisterController@create`を呼び出すことを確認
- [ ] `sail artisan route:list --path=register`で想定したルートになっていることを確認
- [ ] 会員登録画面が正常に表示されることを確認
- [ ] 正しい入力内容で一般ユーザーを登録できることを確認
- [ ] 登録したユーザーが`users`テーブルに保存されることを確認
- [ ] 会員登録成功後、`/attendance`へ遷移することを確認

## 対応Issue

Closes #28
