### PR TITLE
feat: 一般ユーザーログアウト機能を実装 #5

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
+use Laravel\Fortify\Contracts\LogoutResponse;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -21,7 +22,15 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(LogoutResponse::class, function () {
+            return new class implements LogoutResponse
+            {
+                public function toResponse($request)
+                {
+                    return redirect('/login');
+                }
+            };
+        });
     }
 
     /**


### PR DESCRIPTION
## 概要

一般ユーザーがシステムからログアウトできる機能を実装しました。

## 変更内容

- 一般ユーザーのログアウト処理を実装
- Fortifyのログアウト機能を使用

## 動作確認

- [ ] ログイン後にヘッダーのログアウトボタンが表示される
- [ ] ログアウトボタンから正常にログアウトできる
- [ ] ログアウト後にログイン画面へ遷移する
- [ ] ログアウト後、認証が必要な画面にアクセスできない

## 対応issue
close #5 