### PR TITLE
feat: 管理者ログアウト機能を実装 #7

### DIFF
--- a/app/Http/Controllers/AdminLogoutController.php
+++ b/app/Http/Controllers/AdminLogoutController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Laravel\Fortify\Http\Controllers\AuthenticatedSessionController;
+
+class AdminLogoutController extends Controller
+{
+    public function __construct(
+        private AuthenticatedSessionController $logoutController
+    ) {}
+
+    public function destroy(Request $request)
+    {
+        // 管理者ログアウトであることをRequestに保存
+        $request->attributes->set('is_admin_logout', true);
+
+        // Fortifyのログアウト処理を実行
+        return $this->logoutController->destroy($request);
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -27,7 +27,16 @@ class FortifyServiceProvider extends ServiceProvider
             {
                 public function toResponse($request)
                 {
-                    return redirect('/login');
+                    $isAdmin = $request->attributes->get(
+                        'is_admin_logout',
+                        false
+                    );
+
+                    if ($isAdmin) {
+                        return redirect()->route('admin.login');
+                    }
+
+                    return redirect()->route('login');
                 }
             };
         });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AdminLoginController;
+use App\Http\Controllers\AdminLogoutController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\RegisterController;
 use Carbon\Carbon;
@@ -45,6 +46,11 @@ Route::get('/admin/login', [AdminLoginController::class, 'create'])
 // 管理者ログイン処理
 Route::post('/admin/login', [AdminLoginController::class, 'store'])
     ->name('admin.login.store');
+
+// 管理者ログアウト処理
+Route::post('/admin/logout', [AdminLogoutController::class, 'destroy'])
+    ->middleware('auth')
+    ->name('admin.logout');
 
 Route::middleware('auth')->group(function () {
 


### PR DESCRIPTION
## 概要

管理者がシステムからログアウトできる機能を実装しました。

## 変更内容

- 管理者ユーザーのログアウト処理を実装
- Fortifyのログアウト機能を使用

## 動作確認

- [ ] ログイン後にヘッダーのログアウトボタンが表示される
- [ ] ログアウトボタンから正常にログアウトできる
- [ ] ログアウト後にログイン画面へ遷移する
- [ ] ログアウト後、認証が必要な画面にアクセスできない

## 対応issue
close #7 