### PR TITLE
feat: 一般ユーザー勤怠打刻機能を実装 #8

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\AttendanceService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AttendanceController extends Controller
+{
+    public function __construct(
+        private AttendanceService $attendanceService
+    ) {}
+
+    /**
+     * 勤怠登録画面を表示する。
+     */
+    public function create()
+    {
+        $user = Auth::user();
+
+        $attendanceRecord = $this->attendanceService->getTodayRecord($user);
+
+        $user->attendance_status = $this->attendanceService->getStatus(
+            $attendanceRecord
+        );
+
+        $formattedDate = now()->format('Y年m月d日');
+        $formattedTime = now()->format('H:i');
+
+        return view('user.attendance-register', compact(
+            'user',
+            'formattedDate',
+            'formattedTime',
+            'attendanceRecord'
+        ));
+    }
+
+    /**
+     * 勤怠打刻を処理する。
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'action' => ['required', 'in:clock_in,clock_out,break_in,break_out'],
+        ]);
+
+        $error = $this->attendanceService->process(
+            Auth::user(),
+            $request->input('action')
+        );
+
+        if ($error) {
+            return redirect()
+                ->route('attendance.create')
+                ->with('error', $error);
+        }
+
+        return redirect()->route('attendance.create');
+    }
+}

--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -34,6 +34,6 @@ class LoginController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->route('attendance.index');
+        return redirect()->route('attendance.create');
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
@@ -87,5 +88,6 @@ class Kernel extends HttpKernel
         'signed' => ValidateSignature::class,
         'throttle' => ThrottleRequests::class,
         'verified' => EnsureEmailIsVerified::class,
+        'admin' => AdminMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminMiddleware
+{
+    /**
+     * 管理者のみアクセスを許可する。
+     */
+    public function handle(
+        Request $request,
+        Closure $next
+    ): Response {
+        if (! $request->user() || ! $request->user()->admin_status) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Services/AttendanceService.php
+++ b/app/Services/AttendanceService.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceBreak;
+use App\Models\AttendanceRecord;
+use App\Models\User;
+
+class AttendanceService
+{
+    /**
+     * 今日の勤怠記録を取得する。
+     */
+    public function getTodayRecord(User $user): ?AttendanceRecord
+    {
+        return AttendanceRecord::with('breaks')
+            ->where('user_id', $user->id)
+            ->where('date', now()->toDateString())
+            ->first();
+    }
+
+    /**
+     * 勤怠ステータスを取得する。
+     */
+    public function getStatus(?AttendanceRecord $attendanceRecord): string
+    {
+        if (! $attendanceRecord) {
+            return '勤務外';
+        }
+
+        if ($attendanceRecord->clock_out !== null) {
+            return '退勤済';
+        }
+
+        $activeBreak = $attendanceRecord->breaks
+            ->contains(fn (AttendanceBreak $break) => $break->break_out === null);
+
+        return $activeBreak ? '休憩中' : '出勤中';
+    }
+
+    /**
+     * 勤怠打刻を処理する。
+     */
+    public function process(User $user, string $action): ?string
+    {
+        return match ($action) {
+            'clock_in' => $this->clockIn($user),
+            'clock_out' => $this->clockOut($user),
+            'break_in' => $this->breakIn($user),
+            'break_out' => $this->breakOut($user),
+            default => null,
+        };
+    }
+
+    /**
+     * 出勤する。
+     */
+    private function clockIn(User $user): ?string
+    {
+        $attendanceRecord = $this->getTodayRecord($user);
+
+        if ($attendanceRecord) {
+            return '本日はすでに出勤済みです。';
+        }
+
+        AttendanceRecord::create([
+            'user_id' => $user->id,
+            'date' => now()->toDateString(),
+            'clock_in' => now()->format('H:i:s'),
+        ]);
+
+        return null;
+    }
+
+    /**
+     * 休憩を開始する。
+     */
+    private function breakIn(User $user): ?string
+    {
+        $attendanceRecord = $this->getTodayRecord($user);
+
+        if (! $attendanceRecord) {
+            return '出勤していないため、休憩を開始できません。';
+        }
+
+        if ($attendanceRecord->clock_out !== null) {
+            return '退勤済みのため、休憩を開始できません。';
+        }
+
+        if ($this->hasActiveBreak($attendanceRecord)) {
+            return '現在休憩中です。';
+        }
+
+        AttendanceBreak::create([
+            'attendance_record_id' => $attendanceRecord->id,
+            'break_in' => now()->format('H:i:s'),
+        ]);
+
+        return null;
+    }
+
+    /**
+     * 休憩を終了する。
+     */
+    private function breakOut(User $user): ?string
+    {
+        $attendanceRecord = $this->getTodayRecord($user);
+
+        if (! $attendanceRecord) {
+            return '本日の勤怠記録がありません。';
+        }
+
+        $break = AttendanceBreak::where(
+            'attendance_record_id',
+            $attendanceRecord->id
+        )
+            ->whereNull('break_out')
+            ->latest('id')
+            ->first();
+
+        if (! $break) {
+            return '現在休憩中ではありません。';
+        }
+
+        $break->update([
+            'break_out' => now()->format('H:i:s'),
+        ]);
+
+        return null;
+    }
+
+    /**
+     * 退勤する。
+     */
+    private function clockOut(User $user): ?string
+    {
+        $attendanceRecord = $this->getTodayRecord($user);
+
+        if (! $attendanceRecord) {
+            return '本日の勤怠記録がありません。';
+        }
+
+        if ($attendanceRecord->clock_out !== null) {
+            return 'すでに退勤済みです。';
+        }
+
+        if ($this->hasActiveBreak($attendanceRecord)) {
+            return '休憩中は退勤できません。';
+        }
+
+        $attendanceRecord->update([
+            'clock_out' => now()->format('H:i:s'),
+        ]);
+
+        return null;
+    }
+
+    /**
+     * 現在休憩中か確認する。
+     */
+    private function hasActiveBreak(AttendanceRecord $attendanceRecord): bool
+    {
+        return $attendanceRecord->breaks
+            ->contains(fn (AttendanceBreak $break) => $break->break_out === null);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,10 +2,10 @@
 
 use App\Http\Controllers\AdminLoginController;
 use App\Http\Controllers\AdminLogoutController;
+use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\RegisterController;
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -52,26 +52,26 @@ Route::post('/admin/logout', [AdminLogoutController::class, 'destroy'])
     ->middleware('auth')
     ->name('admin.logout');
 
+// 一般ユーザー
 Route::middleware('auth')->group(function () {
 
-    // 仮の勤怠登録画面
-    Route::get('/attendance', function () {
-        $user = Auth::user();
+    // 勤怠登録画面
+    Route::get('/attendance', [AttendanceController::class, 'create'])
+        ->name('attendance.create');
 
-        $formattedDate = Carbon::now()->format('Y年m月d日');
-        $formattedTime = Carbon::now()->format('H:i');
+    // 勤怠打刻処理
+    Route::post('/attendance', [AttendanceController::class, 'store'])
+        ->name('attendance.store');
+});
 
-        // 仮の勤怠状態
-        $user->attendance_status = '勤務外';
+// 管理者
+Route::middleware(['auth', 'admin'])->group(function () {
 
-        return view('user.attendance-register', compact(
-            'user',
-            'formattedDate',
-            'formattedTime'
-        ));
-    })->name('attendance.index');
+    // 管理者ログアウト処理
+    Route::post('/admin/logout', [AdminLogoutController::class, 'destroy'])
+        ->name('admin.logout');
 
-    // 仮の管理者勤怠一覧画面
+    // 管理者勤怠一覧画面
     Route::get('/admin/attendance/list', function () {
         $date = Carbon::today();
 


### PR DESCRIPTION
# 概要

一般ユーザー向けの勤怠打刻機能を実装しました。

## 変更内容

- 勤怠登録画面を表示
- 現在日時の取得・表示処理を実装
- 勤務ステータスの確認処理を実装
- 出勤処理を実装
- 休憩開始処理を実装
- 休憩終了処理を実装
- 退勤処理を実装
- 勤怠記録を `attendance_records` テーブルに保存
- 休憩記録を `breaks` テーブルに保存
- 不正な順番での打刻を防止する処理を実装
- 勤怠処理のロジックをAttendanceServiceに分離

## 動作確認

- [ ] 勤怠登録画面が表示される
- [ ] 現在日時が表示される
- [ ] 「勤務外」ステータスが表示される
- [ ] 「出勤」ボタンを押下できる
- [ ] 出勤後に「出勤中」ステータスへ変更される
- [ ] 出勤時刻が `attendance_records` テーブルに保存される
- [ ] 「休憩入」ボタンを押下できる
- [ ] 休憩開始後に「休憩中」ステータスへ変更される
- [ ] 休憩開始時刻が `breaks` テーブルに保存される
- [ ] 「休憩戻」ボタンを押下できる
- [ ] 休憩終了後に「出勤中」ステータスへ変更される
- [ ] 休憩終了時刻が `breaks` テーブルに保存される
- [ ] 複数回の休憩開始・終了ができる
- [ ] 「退勤」ボタンを押下できる
- [ ] 退勤後に「退勤済」ステータスへ変更される
- [ ] 「お疲れ様でした。」が表示される
- [ ] 退勤時刻が `attendance_records` テーブルに保存される
- [ ] 退勤後に再度出勤できない
- [ ] 休憩中に退勤できない
- [ ] 出勤前に休憩できない
- [ ] 現在休憩中に再度「休憩入」できない

## 対応issue

close #8