### PR TITLE
feat: 一般ユーザー勤怠一覧機能を実装 #9

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\AttendanceListService;
 use App\Services\AttendanceService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -9,7 +10,8 @@ use Illuminate\Support\Facades\Auth;
 class AttendanceController extends Controller
 {
     public function __construct(
-        private AttendanceService $attendanceService
+        private AttendanceService $attendanceService,
+        private AttendanceListService $attendanceListService
     ) {}
 
     /**
@@ -57,5 +59,32 @@ class AttendanceController extends Controller
         }
 
         return redirect()->route('attendance.create');
+    }
+
+    /**
+     * 勤怠一覧画面を表示する。
+     */
+    public function index(Request $request)
+    {
+        $user = Auth::user();
+
+        $date = $request->filled('date')
+            ? now()->createFromFormat('Y-m', $request->input('date'))
+            : now()->startOfMonth();
+
+        $formattedAttendanceRecords = $this->attendanceListService->getMonthlyRecords(
+            $user,
+            $date
+        );
+
+        $previousMonth = $date->copy()->subMonth()->format('Y-m');
+        $nextMonth = $date->copy()->addMonth()->format('Y-m');
+
+        return view('user.user-attendance-list', compact(
+            'date',
+            'previousMonth',
+            'nextMonth',
+            'formattedAttendanceRecords'
+        ));
     }
 }

--- a/app/Services/AttendanceListService.php
+++ b/app/Services/AttendanceListService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class AttendanceListService
+{
+    /**
+     * 指定月の勤怠記録を取得する。
+     */
+    public function getMonthlyRecords(
+        User $user,
+        Carbon $month
+    ): Collection {
+        $attendanceRecords = AttendanceRecord::with('breaks')
+            ->where('user_id', $user->id)
+            ->whereBetween('date', [
+                $month->copy()->startOfMonth()->toDateString(),
+                $month->copy()->endOfMonth()->toDateString(),
+            ])
+            ->get()
+            ->keyBy(function (AttendanceRecord $attendanceRecord) {
+                return $attendanceRecord->date;
+            });
+
+        $records = collect();
+
+        $startDate = $month->copy()->startOfMonth();
+        $endDate = $month->copy()->endOfMonth();
+
+        for (
+            $date = $startDate->copy();
+            $date->lte($endDate);
+            $date->addDay()
+        ) {
+            $dateString = $date->toDateString();
+
+            $attendanceRecord = $attendanceRecords->get($dateString);
+
+            $totalBreakTime = $this->calculateTotalBreakTime(
+                $attendanceRecord
+            );
+
+            $totalWorkTime = $this->calculateTotalWorkTime(
+                $attendanceRecord,
+                $totalBreakTime
+            );
+
+            $records->push([
+                'id' => $attendanceRecord?->id,
+                'date' => $date->format('m/d'),
+                'clock_in' => $attendanceRecord?->clock_in
+                    ? Carbon::parse($attendanceRecord->clock_in)->format('H:i')
+                    : '',
+                'clock_out' => $attendanceRecord?->clock_out
+                    ? Carbon::parse($attendanceRecord->clock_out)->format('H:i')
+                    : '',
+                'total_break_time' => $totalBreakTime,
+                'total_time' => $totalWorkTime,
+            ]);
+        }
+
+        return $records;
+    }
+
+    /**
+     * 休憩時間の合計を計算する。
+     */
+    private function calculateTotalBreakTime(
+        ?AttendanceRecord $attendanceRecord
+    ): ?string {
+        if (! $attendanceRecord) {
+            return null;
+        }
+
+        $totalSeconds = 0;
+
+        foreach ($attendanceRecord->breaks as $break) {
+            if (! $break->break_in || ! $break->break_out) {
+                continue;
+            }
+
+            $breakIn = Carbon::parse($break->break_in);
+            $breakOut = Carbon::parse($break->break_out);
+
+            $totalSeconds += $breakIn->diffInSeconds($breakOut);
+        }
+
+        return $totalSeconds > 0
+            ? gmdate('H:i:s', $totalSeconds)
+            : null;
+    }
+
+    /**
+     * 実働時間を計算する。
+     */
+    private function calculateTotalWorkTime(
+        ?AttendanceRecord $attendanceRecord,
+        ?string $totalBreakTime
+    ): ?string {
+        if (
+            ! $attendanceRecord ||
+            ! $attendanceRecord->clock_in ||
+            ! $attendanceRecord->clock_out
+        ) {
+            return null;
+        }
+
+        $clockIn = Carbon::parse($attendanceRecord->clock_in);
+        $clockOut = Carbon::parse($attendanceRecord->clock_out);
+
+        $workSeconds = $clockIn->diffInSeconds($clockOut);
+
+        if ($totalBreakTime) {
+            $breakSeconds = Carbon::parse($totalBreakTime)
+                ->diffInSeconds(Carbon::parse('00:00:00'));
+
+            $workSeconds -= $breakSeconds;
+        }
+
+        return gmdate('H:i:s', $workSeconds);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,10 @@ Route::middleware('auth')->group(function () {
     // 勤怠打刻処理
     Route::post('/attendance', [AttendanceController::class, 'store'])
         ->name('attendance.store');
+
+    // 勤怠一覧画面
+    Route::get('/attendance/list', [AttendanceController::class, 'index'])
+        ->name('attendance.list');
 });
 
 // 管理者ログイン画面


### PR DESCRIPTION
## 概要

一般ユーザーが自分の勤怠情報を月単位で確認できる勤怠一覧機能を実装しました。

## 動作確認

- []  一般ユーザー勤怠一覧が表示される
- [] 現在月が表示され、前月・翌月へ遷移できる
- [] 1か月分の日付が表示される
- [] 勤怠のない日は空白になる
- [] 休憩時間が表示される
- [] 合計勤務時間が表示される
- [] ログインユーザー自身の勤怠のみ表示される
- [ ] 勤怠詳細のURL（admin/attendance/{id}）に遷移できる

## 対応issue
close #9 