### PR TITLE
一般ユーザー勤怠詳細・修正申請機能を実装 #10

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
 use App\Services\AttendanceListService;
 use App\Services\AttendanceService;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -85,6 +88,56 @@ class AttendanceController extends Controller
             'previousMonth',
             'nextMonth',
             'formattedAttendanceRecords'
+        ));
+    }
+
+    /**
+     * 勤怠詳細画面を表示する。
+     */
+    public function show(int $id)
+    {
+        $user = Auth::user();
+
+        $attendanceRecord = AttendanceRecord::with([
+            'breaks',
+            'correctionRequests',
+        ])
+            ->where('id', $id)
+            ->where('user_id', $user->id)
+            ->firstOrFail();
+
+        $data = [
+            'id' => $attendanceRecord->id,
+            'application' => $attendanceRecord->correctionRequests
+                ->where(
+                    'approval_status',
+                    AttendanceCorrectionRequest::STATUS_PENDING
+                )
+                ->first(),
+            'year' => Carbon::parse($attendanceRecord->date)->format('Y'),
+            'date' => Carbon::parse($attendanceRecord->date)->format('m/d'),
+            'clock_in' => $attendanceRecord->clock_in
+                ? Carbon::parse($attendanceRecord->clock_in)->format('H:i')
+                : '',
+            'clock_out' => $attendanceRecord->clock_out
+                ? Carbon::parse($attendanceRecord->clock_out)->format('H:i')
+                : '',
+            'breaks' => $attendanceRecord->breaks->map(function ($break) {
+                return [
+                    'break_in' => $break->break_in
+                        ? Carbon::parse($break->break_in)->format('H:i')
+                        : '',
+                    'break_out' => $break->break_out
+                        ? Carbon::parse($break->break_out)->format('H:i')
+                        : '',
+                ];
+            })->values()->all(),
+            'comment' => $attendanceRecord->comment ?? '',
+        ];
+
+        return view('user.user-detail', compact(
+            'user',
+            'data'
         ));
     }
 }

--- a/app/Http/Controllers/AttendanceCorrectionRequestController.php
+++ b/app/Http/Controllers/AttendanceCorrectionRequestController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\AttendanceCorrectionRequest as AttendanceCorrectionRequestForm;
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+
+class AttendanceCorrectionRequestController extends Controller
+{
+    /**
+     * 勤怠修正申請を登録する。
+     */
+    public function store(
+        AttendanceCorrectionRequestForm $request,
+        int $id
+    ): RedirectResponse {
+        $user = Auth::user();
+
+        $attendanceRecord = AttendanceRecord::where('id', $id)
+            ->where('user_id', $user->id)
+            ->firstOrFail();
+
+        AttendanceCorrectionRequest::create([
+            'user_id' => $user->id,
+            'attendance_record_id' => $attendanceRecord->id,
+            'approval_status' => AttendanceCorrectionRequest::STATUS_PENDING,
+            'comment' => $request->input('comment'),
+            'new_date' => $attendanceRecord->date,
+            'new_clock_in' => $request->input('new_clock_in'),
+            'new_clock_out' => $request->input('new_clock_out'),
+        ]);
+
+        return redirect()->route('attendance.detail', [
+            'id' => $attendanceRecord->id,
+        ]);
+    }
+}

--- a/app/Http/Requests/AttendanceCorrectionRequest.php
+++ b/app/Http/Requests/AttendanceCorrectionRequest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceCorrectionRequest extends FormRequest
+{
+    /**
+     * リクエストの認可を行う。
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * バリデーションルールを定義する。
+     */
+    public function rules(): array
+    {
+        return [
+            'new_clock_in' => [
+                'required',
+                'date_format:H:i',
+            ],
+
+            'new_clock_out' => [
+                'required',
+                'date_format:H:i',
+            ],
+
+            'new_break_in' => [
+                'nullable',
+                'array',
+            ],
+
+            'new_break_in.*' => [
+                'nullable',
+                'date_format:H:i',
+            ],
+
+            'new_break_out' => [
+                'nullable',
+                'array',
+            ],
+
+            'new_break_out.*' => [
+                'nullable',
+                'date_format:H:i',
+            ],
+
+            'comment' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+        ];
+    }
+
+    /**
+     * バリデーション後の追加チェックを行う。
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            $clockIn = $this->input('new_clock_in');
+            $clockOut = $this->input('new_clock_out');
+
+            /*
+            * 出勤・退勤の前後関係を確認する。
+            */
+            if ($clockIn && $clockOut && $clockIn > $clockOut) {
+                $validator->errors()->add(
+                    'new_clock_in',
+                    '出勤時間もしくは退勤時間が不適切な値です'
+                );
+            }
+
+            /*
+            * 休憩時間の前後関係を確認する。
+            */
+            $breakIns = $this->input('new_break_in', []);
+            $breakOuts = $this->input('new_break_out', []);
+
+            foreach ($breakIns as $index => $breakIn) {
+                $breakOut = $breakOuts[$index] ?? null;
+
+                /*
+                * 休憩開始・終了はセットで入力する。
+                */
+                if (($breakIn && ! $breakOut) || (! $breakIn && $breakOut)) {
+                    $validator->errors()->add(
+                        "new_break_in.$index",
+                        '休憩時間を開始・終了ともに入力してください。'
+                    );
+
+                    continue;
+                }
+
+                /*
+                * 休憩開始時間が出勤より前、
+                * または退勤より後の場合。
+                */
+                if (
+                    $breakIn
+                    && $clockIn
+                    && $clockOut
+                    && ($breakIn < $clockIn || $breakIn > $clockOut)
+                ) {
+                    $validator->errors()->add(
+                        "new_break_in.$index",
+                        '休憩時間が不適切な値です'
+                    );
+                }
+
+                /*
+                * 休憩終了時間が退勤より後の場合。
+                */
+                if ($breakOut && $clockOut && $breakOut > $clockOut) {
+                    $validator->errors()->add(
+                        "new_break_out.$index",
+                        '休憩時間もしくは退勤時間が不適切な値です'
+                    );
+                }
+
+                /*
+                * 休憩終了時間が休憩開始より前の場合。
+                */
+                if ($breakIn && $breakOut && $breakOut < $breakIn) {
+                    $validator->errors()->add(
+                        "new_break_out.$index",
+                        '休憩時間が不適切な値です'
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * バリデーションエラーメッセージを定義する。
+     */
+    public function messages(): array
+    {
+        return [
+            'new_clock_in.required' => '出勤時間を入力してください。',
+            'new_clock_in.date_format' => '出勤時間は正しい形式で入力してください。',
+
+            'new_clock_out.required' => '退勤時間を入力してください。',
+            'new_clock_out.date_format' => '退勤時間は正しい形式で入力してください。',
+
+            'new_break_in.*.date_format' => '休憩時間は正しい形式で入力してください。',
+
+            'new_break_out.*.date_format' => '休憩時間は正しい形式で入力してください。',
+
+            'comment.required' => '備考を記入してください。',
+            'comment.string' => '備考は文字列で入力してください。',
+            'comment.max' => '備考は255文字以内で入力してください。',
+        ];
+    }
+}

--- a/app/Models/AttendanceCorrectionRequest.php
+++ b/app/Models/AttendanceCorrectionRequest.php
@@ -11,6 +11,10 @@ class AttendanceCorrectionRequest extends Model
 {
     use HasFactory;
 
+    public const STATUS_PENDING = 0;
+
+    public const STATUS_APPROVED = 1;
+
     protected $fillable = [
         'user_id',
         'attendance_record_id',

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AdminLoginController;
 use App\Http\Controllers\AdminLogoutController;
 use App\Http\Controllers\AttendanceController;
+use App\Http\Controllers\AttendanceCorrectionRequestController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\RegisterController;
 use Carbon\Carbon;
@@ -45,6 +46,16 @@ Route::middleware('auth')->group(function () {
     // 勤怠一覧画面
     Route::get('/attendance/list', [AttendanceController::class, 'index'])
         ->name('attendance.list');
+
+    // 勤怠詳細画面
+    Route::get('/attendance/{id}', [AttendanceController::class, 'show'])
+        ->name('attendance.detail');
+
+    // 勤怠修正申請処理
+    Route::post(
+        '/attendance/{id}',
+        [AttendanceCorrectionRequestController::class, 'store']
+    )->name('attendance.correction.store');
 });
 
 // 管理者ログイン画面


### PR DESCRIPTION
## 概要

一般ユーザーが自身の勤怠詳細を確認し、勤怠情報の修正申請を行える機能を実装しました。

## 実装内容

- 一般ユーザー向け勤怠詳細画面を実装
- 出勤・退勤時間、休憩時間、備考の修正入力を実装
- FormRequestによるバリデーションを実装
- 出勤・退勤時間の前後関係チェック
- 休憩時間と出勤・退勤時間の前後関係チェック
- 休憩開始・終了の片方だけ入力チェック
- バリデーションエラーメッセージの表示
- 勤怠修正申請をデータベースへ登録
- 承認待ちの修正申請がある場合は修正不可とし、メッセージを表示
- ログインユーザー以外の勤怠にはアクセスできないよう制御

## 動作確認

- [ ] 勤怠詳細（一般ユーザー用）が表示される
- [ ] 勤怠詳細（一般ユーザー用）を取得できる
- [ ] 勤怠情報（一般ユーザー用）を編集できる
- [ ] バリデーションが動作する
- [ ] エラーメッセージが表示される
- [ ] 修正申請できる
- [ ] 他ユーザーの勤怠を操作できない

## 対応issue
close #10 
