### PR TITLE
一般ユーザーの申請一覧・詳細機能を実装 #11

### DIFF
--- a/app/Http/Controllers/AttendanceCorrectionRequestController.php
+++ b/app/Http/Controllers/AttendanceCorrectionRequestController.php
@@ -11,6 +11,53 @@ use Illuminate\Support\Facades\Auth;
 class AttendanceCorrectionRequestController extends Controller
 {
     /**
+     * 勤怠修正申請一覧を表示する。
+     */
+    public function index()
+    {
+        $user = Auth::user();
+
+        $applications = AttendanceCorrectionRequest::with(['attendanceRecord'])
+            ->where('user_id', $user->id)
+            ->get();
+
+        $formattedApplications = $applications->map(function (
+            AttendanceCorrectionRequest $application
+        ) {
+            return [
+                'id' => $application->id,
+                'approval_status' => $application->approval_status === AttendanceCorrectionRequest::STATUS_PENDING
+                    ? '承認待ち'
+                    : '承認済み',
+                'date' => $application->attendanceRecord->date,
+                'comment' => $application->comment,
+                'application_date' => $application->created_at->format('Y-m-d H:i:s'),
+            ];
+        });
+
+        return view('user.user-application-list', compact(
+            'user',
+            'formattedApplications'
+        ));
+    }
+
+    /**
+     * 勤怠修正申請の詳細から勤怠詳細画面へ遷移する。
+     */
+    public function show(int $id)
+    {
+        $user = Auth::user();
+
+        $application = AttendanceCorrectionRequest::where('id', $id)
+            ->where('user_id', $user->id)
+            ->firstOrFail();
+
+        return redirect()->route('attendance.detail', [
+            'id' => $application->attendance_record_id,
+        ]);
+    }
+
+    /**
      * 勤怠修正申請を登録する。
      */
     public function store(

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,6 +56,18 @@ Route::middleware('auth')->group(function () {
         '/attendance/{id}',
         [AttendanceCorrectionRequestController::class, 'store']
     )->name('attendance.correction.store');
+
+    // 勤怠修正申請一覧画面
+    Route::get(
+        '/stamp_correction_request/list',
+        [AttendanceCorrectionRequestController::class, 'index']
+    )->name('attendance.correction.index');
+
+    // 勤怠修正申請詳細画面
+    Route::get(
+        '/application/{id}',
+        [AttendanceCorrectionRequestController::class, 'show']
+    )->name('attendance.correction.show');
 });
 
 // 管理者ログイン画面


### PR DESCRIPTION
## 概要

一般ユーザーが自身の勤怠修正申請を確認できる申請一覧・詳細機能を実装しました。

## 実装内容

- 一般ユーザー向け勤怠修正申請一覧画面を実装
- 承認待ちの勤怠修正申請を取得・表示
- 承認済みの勤怠修正申請を取得・表示
- 申請一覧から勤怠詳細画面へ遷移できる機能を実装
- ログインユーザー自身の申請のみ取得できるよう制御
- 他ユーザーの申請にはアクセスできないよう制御
- 既存の勤怠詳細画面を利用して申請詳細を表示

## 動作確認

- [ ] 勤怠修正申請一覧（一般ユーザー用）が表示される
- [ ] 承認待ち申請を取得・表示できる
- [ ] 承認済み申請を取得・表示できる
- [ ] 申請一覧の「詳細」から勤怠詳細画面へ遷移できる
- [ ] 他ユーザーの申請が表示されない
- [ ] 他ユーザーの申請に直接アクセスできない

## 対応issue

close #11