### PR TITLE
feat: 管理者勤怠一覧機能を実装 #12

### DIFF
--- a/app/Http/Controllers/AdminAttendanceController.php
+++ b/app/Http/Controllers/AdminAttendanceController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\AdminAttendanceService;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class AdminAttendanceController extends Controller
+{
+    public function __construct(
+        private AdminAttendanceService $adminAttendanceService
+    ) {}
+
+    /**
+     * 管理者勤怠一覧画面を表示する。
+     */
+    public function index(Request $request)
+    {
+        $date = $request->filled('date')
+            ? Carbon::createFromFormat(
+                'Y-m-d',
+                $request->input('date')
+            )
+            : Carbon::today();
+
+        $users = $this->adminAttendanceService->getUsers();
+
+        $attendanceRecords = $this->adminAttendanceService
+            ->getDailyRecords($date);
+
+        $previousDay = $date->copy()
+            ->subDay()
+            ->format('Y-m-d');
+
+        $nextDay = $date->copy()
+            ->addDay()
+            ->format('Y-m-d');
+
+        return view('admin.admin-attendance-list', compact(
+            'date',
+            'previousDay',
+            'nextDay',
+            'users',
+            'attendanceRecords'
+        ));
+    }
+}

--- a/app/Services/AdminAttendanceService.php
+++ b/app/Services/AdminAttendanceService.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class AdminAttendanceService
+{
+    /**
+     * 全ユーザーを取得する。
+     */
+    public function getUsers(): Collection
+    {
+        return User::all();
+    }
+
+    /**
+     * 指定日の勤怠記録を取得する。
+     */
+    public function getDailyRecords(Carbon $date): Collection
+    {
+        $attendanceRecords = AttendanceRecord::with('breaks')
+            ->whereDate('date', $date)
+            ->get();
+
+        foreach ($attendanceRecords as $attendanceRecord) {
+            $totalBreakTime = $this->calculateTotalBreakTime(
+                $attendanceRecord
+            );
+
+            $totalWorkTime = $this->calculateTotalWorkTime(
+                $attendanceRecord,
+                $totalBreakTime
+            );
+
+            $attendanceRecord->total_break_time = $totalBreakTime;
+            $attendanceRecord->total_time = $totalWorkTime;
+        }
+
+        return $attendanceRecords;
+    }
+
+    /**
+     * 休憩時間の合計を計算する。
+     */
+    private function calculateTotalBreakTime(
+        AttendanceRecord $attendanceRecord
+    ): ?string {
+        $totalSeconds = 0;
+
+        foreach ($attendanceRecord->breaks as $break) {
+            if (! $break->break_in || ! $break->break_out) {
+                continue;
+            }
+
+            $breakIn = Carbon::parse($break->break_in);
+            $breakOut = Carbon::parse($break->break_out);
+
+            $totalSeconds += $breakIn->diffInSeconds($breakOut);
+        }
+
+        return $totalSeconds > 0
+            ? gmdate('H:i:s', $totalSeconds)
+            : null;
+    }
+
+    /**
+     * 実働時間を計算する。
+     */
+    private function calculateTotalWorkTime(
+        AttendanceRecord $attendanceRecord,
+        ?string $totalBreakTime
+    ): ?string {
+        if (
+            ! $attendanceRecord->clock_in ||
+            ! $attendanceRecord->clock_out
+        ) {
+            return null;
+        }
+
+        $clockIn = Carbon::parse($attendanceRecord->clock_in);
+        $clockOut = Carbon::parse($attendanceRecord->clock_out);
+
+        $workSeconds = $clockIn->diffInSeconds($clockOut);
+
+        if ($totalBreakTime) {
+            $breakSeconds = Carbon::parse($totalBreakTime)
+                ->diffInSeconds(Carbon::parse('00:00:00'));
+
+            $workSeconds -= $breakSeconds;
+        }
+
+        return gmdate('H:i:s', $workSeconds);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,12 +1,12 @@
 <?php
 
+use App\Http\Controllers\AdminAttendanceController;
 use App\Http\Controllers\AdminLoginController;
 use App\Http\Controllers\AdminLogoutController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\AttendanceCorrectionRequestController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\RegisterController;
-use Carbon\Carbon;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -74,6 +74,10 @@ Route::middleware('auth')->group(function () {
 Route::get('/admin/login', [AdminLoginController::class, 'create'])
     ->name('admin.login');
 
+// 管理者ログイン処理
+Route::post('/admin/login', [AdminLoginController::class, 'store'])
+    ->name('admin.login.store');
+
 // 管理者
 Route::middleware(['auth', 'admin'])->group(function () {
 
@@ -82,21 +86,8 @@ Route::middleware(['auth', 'admin'])->group(function () {
         ->name('admin.logout');
 
     // 管理者勤怠一覧画面
-    Route::get('/admin/attendance/list', function () {
-        $date = Carbon::today();
-
-        $previousDay = $date->copy()->subDay()->format('Y-m-d');
-        $nextDay = $date->copy()->addDay()->format('Y-m-d');
-
-        $users = collect();
-        $attendanceRecords = collect();
-
-        return view('admin.admin-attendance-list', compact(
-            'date',
-            'previousDay',
-            'nextDay',
-            'users',
-            'attendanceRecords'
-        ));
-    })->name('admin.attendance.list');
+    Route::get(
+        '/admin/attendance/list',
+        [AdminAttendanceController::class, 'index']
+    )->name('admin.attendance.list');
 });


### PR DESCRIPTION
## 概要

管理者がスタッフの勤怠情報を日別に確認できる、管理者向け勤怠一覧機能を実装しました。

## 実装内容

- 管理者向け勤怠一覧画面を実装
- 指定日のスタッフの勤怠情報を取得・表示
- 出勤・退勤時間を表示
- 休憩時間の合計を表示
- 実働時間の合計を表示
- 現在の日付を初期表示
- 「前日」「翌日」による日付変更機能を実装
- 各勤怠の「詳細」から勤怠詳細画面へ遷移できるよう実装
- 管理者認証によるアクセス制御
- 管理者勤怠一覧の取得・計算処理を `AdminAttendanceService` に分離

## 動作確認

- [ ] 勤怠一覧（管理者用）が表示される
- [ ] 指定日のスタッフの勤怠情報を取得できる
- [ ] 出勤時間が正しく表示される
- [ ] 退勤時間が正しく表示される
- [ ] 勤怠中など、未実施の項目が空白で表示される
- [ ] 休憩時間が正しく表示される
- [ ] 実働時間が正しく表示される
- [ ] 「前日」を押すと前日の勤怠一覧が表示される
- [ ] 「翌日」を押すと翌日の勤怠一覧が表示される
- [ ] 「詳細」から勤怠詳細画面へ遷移できる
- [ ] 管理者以外は管理者勤怠一覧にアクセスできない

## 対応Issue

close #12