### PR TITLE
test: 認証機能のテストを追加 #18

### DIFF
--- a/tests/Feature/Auth/AdminLoginTest.php
+++ b/tests/Feature/Auth/AdminLoginTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class AdminLoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * メールアドレスが未入力の場合、バリデーションエラーになる
+     */
+    public function test_email_is_required(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('password'),
+            'admin_status' => true,
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => '',
+            'password' => 'password',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => 'メールアドレスを入力してください',
+        ]);
+    }
+
+    /**
+     * パスワードが未入力の場合、バリデーションエラーになる
+     */
+    public function test_password_is_required(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('password'),
+            'admin_status' => true,
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => $user->email,
+            'password' => '',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'password' => 'パスワードを入力してください',
+        ]);
+    }
+
+    /**
+     * 登録内容と一致しない場合、ログインできない
+     */
+    public function test_login_fails_with_invalid_credentials(): void
+    {
+        User::factory()->create([
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+            'admin_status' => true,
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => 'wrong@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => 'ログイン情報が登録されていません',
+        ]);
+
+        $this->assertGuest();
+    }
+
+    /**
+     * 管理者の正しい認証情報の場合、ログインできる
+     */
+    public function test_admin_can_login(): void
+    {
+        $admin = User::factory()->create([
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+            'admin_status' => true,
+        ]);
+
+        $response = $this->post('/admin/login', [
+            'email' => 'admin@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect(route('admin.attendance.list'));
+
+        $this->assertAuthenticatedAs($admin);
+    }
+}

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * メールアドレスが未入力の場合、バリデーションエラーになる
+     */
+    public function test_email_is_required(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('password'),
+            'admin_status' => false,
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => '',
+            'password' => 'password',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => 'メールアドレスを入力してください',
+        ]);
+    }
+
+    /**
+     * パスワードが未入力の場合、バリデーションエラーになる
+     */
+    public function test_password_is_required(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('password'),
+            'admin_status' => false,
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => $user->email,
+            'password' => '',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'password' => 'パスワードを入力してください',
+        ]);
+    }
+
+    /**
+     * 登録内容と一致しない場合、ログインできない
+     */
+    public function test_login_fails_with_invalid_credentials(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+            'password' => Hash::make('password'),
+            'admin_status' => false,
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => 'wrong@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => 'ログイン情報が登録されていません',
+        ]);
+
+        $this->assertGuest();
+    }
+
+    /**
+     * 正しい認証情報の場合、ログインできる
+     */
+    public function test_user_can_login(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'test@example.com',
+            'password' => Hash::make('password'),
+            'admin_status' => false,
+        ]);
+
+        $response = $this->post('/login', [
+            'email' => 'test@example.com',
+            'password' => 'password',
+        ]);
+
+        $response->assertRedirect(route('attendance.create'));
+
+        $this->assertAuthenticatedAs($user);
+    }
+}

--- a/tests/Feature/Auth/RegisterTest.php
+++ b/tests/Feature/Auth/RegisterTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RegisterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 名前が未入力の場合、バリデーションエラーになる
+     */
+    public function test_name_is_required(): void
+    {
+        $response = $this->post('/register', [
+            'name' => '',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'name' => 'お名前を入力してください',
+        ]);
+    }
+
+    /**
+     * メールアドレスが未入力の場合、バリデーションエラーになる
+     */
+    public function test_email_is_required(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'テストユーザー',
+            'email' => '',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => 'メールアドレスを入力してください',
+        ]);
+    }
+
+    /**
+     * パスワードが8文字未満の場合、バリデーションエラーになる
+     */
+    public function test_password_must_be_at_least_8_characters(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'password' => '1234567',
+            'password_confirmation' => '1234567',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'password' => 'パスワードは8文字以上で入力してください',
+        ]);
+    }
+
+    /**
+     * パスワードと確認用パスワードが一致しない場合、バリデーションエラーになる
+     */
+    public function test_password_confirmation_must_match(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'different',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'password' => 'パスワードと一致しません',
+        ]);
+    }
+
+    /**
+     * パスワードが未入力の場合、バリデーションエラーになる
+     */
+    public function test_password_is_required(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'password' => '',
+            'password_confirmation' => '',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'password' => 'パスワードを入力してください',
+        ]);
+    }
+
+    /**
+     * 正しい入力の場合、ユーザーが正常に登録される
+     */
+    public function test_user_can_register(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertRedirect(route('attendance.create'));
+
+        $this->assertDatabaseHas('users', [
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+            'admin_status' => false,
+        ]);
+
+        $this->assertAuthenticated();
+    }
+}


### PR DESCRIPTION
## 概要

認証機能のFeatureテストを実装しました。

## 変更内容

- 一般ユーザー会員登録のFeatureテストを作成
- 名前未入力時のバリデーションテストを追加
- メールアドレス未入力時のバリデーションテストを追加
- パスワード8文字未満時のバリデーションテストを追加
- パスワード不一致時のバリデーションテストを追加
- パスワード未入力時のバリデーションテストを追加
- 正常なユーザー登録処理のテストを追加
- ユーザー登録後の認証状態確認テストを追加
- 一般ユーザーログインのFeatureテストを作成
- メールアドレス未入力時のバリデーションテストを追加
- パスワード未入力時のバリデーションテストを追加
- 誤った認証情報によるログイン失敗テストを追加
- 正しい認証情報によるログイン成功テストを追加
- 管理者ログインのFeatureテストを作成
- メールアドレス未入力時のバリデーションテストを追加
- パスワード未入力時のバリデーションテストを追加
- 誤った認証情報によるログイン失敗テストを追加
- 正しい認証情報によるログイン成功テストを追加
- `UserFactory` を利用してテストデータを作成

## テスト項目

- RegisterTest（6テスト：正常系1・異常系5）
- LoginTest（4テスト：正常系1・異常系3）
- AdminLoginTest（4テスト：正常系1・異常系3）

## 対応Issue

close #18
