### PR TITLE
Feature/issue 42 authentication test additional

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -12,6 +12,13 @@ class Authenticate extends Middleware
      */
     protected function redirectTo(Request $request): ?string
     {
+        if (
+            $request->is('admin/*')
+            || $request->is('stamp_correction_request/approve/*')
+        ) {
+            return route('admin.login');
+        }
+
         return $request->expectsJson() ? null : route('login');
     }
 }

--- a/tests/Feature/Auth/AdminLoginTest.php
+++ b/tests/Feature/Auth/AdminLoginTest.php
@@ -94,4 +94,32 @@ class AdminLoginTest extends TestCase
 
         $this->assertAuthenticatedAs($admin);
     }
+
+    /**
+     * 管理者がログアウトできる
+     */
+    public function test_admin_can_logout(): void
+    {
+        $admin = User::factory()->create([
+            'admin_status' => true,
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->post('/admin/logout');
+
+        $response->assertRedirect('/admin/login');
+
+        $this->assertGuest();
+    }
+
+    /**
+     * 未認証ユーザーは管理画面にアクセスできない
+     */
+    public function test_guest_cannot_access_admin_attendance(): void
+    {
+        $response = $this->get('/admin/attendance/list');
+
+        $response->assertRedirect('/admin/login');
+    }
 }

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -94,4 +94,43 @@ class LoginTest extends TestCase
 
         $this->assertAuthenticatedAs($user);
     }
+
+    /**
+     * 一般ユーザーがログアウトできる
+     */
+    public function test_user_can_logout(): void
+    {
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->post('/logout');
+
+        $response->assertRedirect('/login');
+
+        $this->assertGuest();
+    }
+
+    /**
+     * 未認証ユーザーは勤怠画面にアクセスできない
+     */
+    public function test_guest_cannot_access_attendance(): void
+    {
+        $response = $this->get('/attendance');
+
+        $response->assertRedirect('/login');
+    }
+
+    /**
+     * ログイン画面から会員登録画面へ遷移できる
+     */
+    public function test_login_page_has_register_link(): void
+    {
+        $response = $this->get('/login');
+
+        $response->assertStatus(200);
+        $response->assertSee(('/register'));
+    }
 }

--- a/tests/Feature/Auth/RegisterTest.php
+++ b/tests/Feature/Auth/RegisterTest.php
@@ -95,6 +95,23 @@ class RegisterTest extends TestCase
     }
 
     /**
+     * メールアドレスがメール形式ではない場合、バリデーションエラーになる
+     */
+    public function test_email_must_be_valid_format(): void
+    {
+        $response = $this->post('/register', [
+            'name' => 'テストユーザー',
+            'email' => 'invalid-email',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ]);
+
+        $response->assertSessionHasErrors([
+            'email' => 'メールアドレスはメール形式で入力してください',
+        ]);
+    }
+
+    /**
      * 正しい入力の場合、ユーザーが正常に登録される
      */
     public function test_user_can_register(): void
@@ -115,5 +132,17 @@ class RegisterTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
+    }
+
+    /**
+     * 会員登録画面からログイン画面へ遷移できる
+     */
+    public function test_register_page_has_login_link(): void
+    {
+        $response = $this->get('/register');
+
+        $response->assertStatus(200);
+        $response->assertSee('ログイン');
+        $response->assertSee('/login');
     }
 }


### PR DESCRIPTION
# 概要

認証機能のFeatureテストを追加し、一般ユーザー・管理者の認証処理およびアクセス制御を確認できるようにしました。

## 変更内容

- 一般ユーザーの会員登録テストを追加
- 一般ユーザーのログインテストを追加
- 一般ユーザーのログアウトテストを追加
- 管理者のログインテストを追加
- 管理者のログアウトテストを追加
- メールアドレス形式のバリデーションテストを追加
- 未認証ユーザーの一般画面アクセス制御テストを追加
- 未認証ユーザーの管理画面アクセス制御テストを追加
- `/register` → `/login` の導線テストを追加
- `/login` → `/register` の導線テストを追加
- 管理者画面への未認証アクセス時に `/admin/login` へリダイレクトするようMiddlewareを修正

## テスト項目

- RegisterTest（7テスト：正常系1・異常系5・境界値1）
- LoginTest（7テスト：正常系3・異常系3・境界値1）
- AdminLoginTest（6テスト：正常系2・異常系3・境界値1）

# 対応issue
close #42 
