### PR TITLE
test: 一般ユーザー勤怠機能テスト #19

### DIFF
--- a/app/Http/Requests/AttendanceCorrectionRequest.php
+++ b/app/Http/Requests/AttendanceCorrectionRequest.php
@@ -73,7 +73,7 @@ class AttendanceCorrectionRequest extends FormRequest
             if ($clockIn && $clockOut && $clockIn > $clockOut) {
                 $validator->errors()->add(
                     'new_clock_in',
-                    '出勤時間もしくは退勤時間が不適切な値です'
+                    '出勤時間もしくは退勤時間が不適切な値です。'
                 );
             }
 
@@ -110,7 +110,7 @@ class AttendanceCorrectionRequest extends FormRequest
                 ) {
                     $validator->errors()->add(
                         "new_break_in.$index",
-                        '休憩時間が不適切な値です'
+                        '休憩時間が不適切な値です。'
                     );
                 }
 
@@ -120,7 +120,7 @@ class AttendanceCorrectionRequest extends FormRequest
                 if ($breakOut && $clockOut && $breakOut > $clockOut) {
                     $validator->errors()->add(
                         "new_break_out.$index",
-                        '休憩時間もしくは退勤時間が不適切な値です'
+                        '休憩時間もしくは退勤時間が不適切な値です。'
                     );
                 }
 
@@ -130,7 +130,7 @@ class AttendanceCorrectionRequest extends FormRequest
                 if ($breakIn && $breakOut && $breakOut < $breakIn) {
                     $validator->errors()->add(
                         "new_break_out.$index",
-                        '休憩時間が不適切な値です'
+                        '休憩時間が不適切な値です。'
                     );
                 }
             }

--- a/tests/Feature/Attendance/AttendanceBreakTest.php
+++ b/tests/Feature/Attendance/AttendanceBreakTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Models\AttendanceBreak;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceBreakTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 休憩ボタンが正しく機能する
+     */
+    public function test_user_can_start_break(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('休憩入');
+
+        $this->post('/attendance', [
+            'action' => 'break_in',
+        ]);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('休憩中');
+
+        $this->assertDatabaseHas('breaks', [
+            'attendance_record_id' => $attendanceRecord->id,
+        ]);
+    }
+
+    /**
+     * 休憩は一日に何回でもできる
+     */
+    public function test_user_can_take_multiple_breaks(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        // 1回目の休憩
+        $this->post('/attendance', [
+            'action' => 'break_in',
+        ]);
+
+        $this->post('/attendance', [
+            'action' => 'break_out',
+        ]);
+
+        // 2回目の休憩
+        $response = $this->get('/attendance');
+
+        $response->assertSee('休憩入');
+
+        $this->post('/attendance', [
+            'action' => 'break_in',
+        ]);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('休憩中');
+
+        $this->assertCount(
+            2,
+            AttendanceBreak::where(
+                'attendance_record_id',
+                $attendanceRecord->id
+            )->get()
+        );
+    }
+
+    /**
+     * 休憩戻ボタンが正しく機能する
+     */
+    public function test_user_can_end_break(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        // 休憩開始
+        $this->post('/attendance', [
+            'action' => 'break_in',
+        ]);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('休憩戻');
+
+        // 休憩終了
+        $this->post('/attendance', [
+            'action' => 'break_out',
+        ]);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('出勤中');
+
+        $this->assertDatabaseMissing('breaks', [
+            'attendance_record_id' => $attendanceRecord->id,
+            'break_out' => null,
+        ]);
+    }
+
+    /**
+     * 休憩戻は一日に何回でもできる
+     */
+    public function test_user_can_end_multiple_breaks(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        // 1回目の休憩
+        $this->post('/attendance', [
+            'action' => 'break_in',
+        ]);
+
+        $this->post('/attendance', [
+            'action' => 'break_out',
+        ]);
+
+        // 2回目の休憩
+        $this->post('/attendance', [
+            'action' => 'break_in',
+        ]);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('休憩戻');
+
+        $this->post('/attendance', [
+            'action' => 'break_out',
+        ]);
+
+        $this->assertCount(
+            2,
+            AttendanceBreak::where(
+                'attendance_record_id',
+                $attendanceRecord->id
+            )->get()
+        );
+    }
+
+    /**
+     * 休憩時刻が勤怠一覧画面で確認できる
+     */
+    public function test_break_time_is_recorded(): void
+    {
+        $this->travelTo(now()->setTime(12, 0));
+
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        // 12:00に休憩開始
+        $this->post('/attendance', [
+            'action' => 'break_in',
+        ]);
+
+        // 13:00に休憩終了
+        $this->travelTo(now()->setTime(13, 0));
+
+        $this->post('/attendance', [
+            'action' => 'break_out',
+        ]);
+
+        // DBに休憩時間が保存されていることを確認
+        $break = AttendanceBreak::where(
+            'attendance_record_id',
+            $attendanceRecord->id
+        )->first();
+
+        $this->assertNotNull($break);
+        $this->assertNotNull($break->break_in);
+        $this->assertNotNull($break->break_out);
+
+        $this->assertEquals('12:00:00', $break->break_in);
+        $this->assertEquals('13:00:00', $break->break_out);
+
+        // 勤怠一覧画面を確認
+        $response = $this->get('/attendance/list');
+
+        $response->assertStatus(200);
+
+        // 休憩1時間が「1:00」と表示される
+        $response->assertSee('1:00');
+
+        $this->travelBack();
+    }
+}

--- a/tests/Feature/Attendance/AttendanceClockTest.php
+++ b/tests/Feature/Attendance/AttendanceClockTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceClockTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 出勤ボタンが正しく機能する
+     */
+    public function test_user_can_clock_in(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        // 勤怠打刻画面を開く
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+
+        // 「出勤」ボタンが表示されていることを確認
+        $response->assertSee('出勤');
+
+        // 出勤処理を行う
+        $response = $this->post('/attendance', [
+            'action' => 'clock_in',
+        ]);
+
+        $response->assertRedirect('/attendance');
+
+        // 出勤後の勤怠打刻画面を開く
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+
+        // ステータスが「出勤中」になっていることを確認
+        $response->assertSee('出勤中');
+
+        // 勤怠記録が保存されていることを確認
+        $this->assertDatabaseHas('attendance_records', [
+            'user_id' => $user->id,
+            'date' => now()->toDateString(),
+        ]);
+    }
+
+    /**
+     * 出勤は一日一回のみできる
+     */
+    public function test_user_can_clock_in_only_once_per_day(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->post('/attendance', [
+            'action' => 'clock_in',
+        ]);
+
+        $response->assertRedirect('/attendance');
+
+        $response->assertSessionHas(
+            'error',
+            '本日はすでに出勤済みです。'
+        );
+
+        $this->assertDatabaseCount('attendance_records', 1);
+    }
+
+    /**
+     * 出勤時刻が勤怠一覧画面で確認できる
+     */
+    public function test_clock_in_time_is_recorded(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $this->post('/attendance', [
+            'action' => 'clock_in',
+        ]);
+
+        $attendanceRecord = AttendanceRecord::where(
+            'user_id',
+            $user->id
+        )->first();
+
+        $this->assertNotNull($attendanceRecord);
+
+        $response = $this->get('/attendance/list');
+
+        $response->assertStatus(200);
+        $response->assertSee(
+            date('H:i', strtotime($attendanceRecord->clock_in))
+        );
+    }
+
+    /**
+     * 退勤ボタンが正しく機能する
+     */
+    public function test_user_can_clock_out(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        // 勤怠打刻画面を開く
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+
+        // 「退勤」ボタンが表示されていることを確認
+        $response->assertSee('退勤');
+
+        // 退勤処理を行う
+        $response = $this->post('/attendance', [
+            'action' => 'clock_out',
+        ]);
+
+        $response->assertRedirect('/attendance');
+
+        // 退勤後の勤怠打刻画面を開く
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+
+        // ステータスが「退勤済」になっていることを確認
+        $response->assertSee('退勤済');
+
+        $attendanceRecord->refresh();
+
+        $this->assertNotNull($attendanceRecord->clock_out);
+    }
+
+    /**
+     * 退勤時刻が勤怠一覧画面で確認できる
+     */
+    public function test_clock_out_time_is_recorded(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        // 出勤処理
+        $this->post('/attendance', [
+            'action' => 'clock_in',
+        ]);
+
+        // 退勤処理
+        $this->post('/attendance', [
+            'action' => 'clock_out',
+        ]);
+
+        // 勤怠一覧画面を表示
+        $response = $this->get('/attendance/list');
+
+        $response->assertStatus(200);
+
+        // 退勤時刻が表示されていることを確認
+        $attendanceRecord = AttendanceRecord::where(
+            'user_id',
+            $user->id
+        )->first();
+
+        $response->assertSee(
+            date('H:i', strtotime($attendanceRecord->clock_out))
+        );
+    }
+}

--- a/tests/Feature/Attendance/AttendanceCorrectionListTest.php
+++ b/tests/Feature/Attendance/AttendanceCorrectionListTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceCorrectionListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 承認待ちに自分の申請が全て表示される
+     */
+    public function test_pending_requests_are_displayed(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '10:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['12:00'],
+                'new_break_out' => ['13:00'],
+                'comment' => '1件目の修正申請',
+            ]
+        )->assertRedirect();
+
+        $attendanceRecord2 = AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->subDay()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        $this->post(
+            '/attendance/detail/'.$attendanceRecord2->id,
+            [
+                'new_clock_in' => '11:00',
+                'new_clock_out' => '19:00',
+                'new_break_in' => ['12:00'],
+                'new_break_out' => ['13:00'],
+                'comment' => '2件目の修正申請',
+            ]
+        )->assertRedirect();
+
+        $response = $this->get('/stamp_correction_request/list');
+
+        $response->assertStatus(200);
+        $response->assertSee('1件目の修正申請');
+        $response->assertSee('2件目の修正申請');
+    }
+
+    /**
+     * 管理者が承認した複数の申請が
+     * 「承認済み」に全て表示される
+     */
+    public function test_approved_requests_are_displayed(): void
+    {
+        [$user, $attendanceRecord] = $this->createAttendanceUser();
+
+        $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '10:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['12:00'],
+                'new_break_out' => ['13:00'],
+                'comment' => '承認済み申請テスト1',
+            ]
+        )->assertRedirect();
+
+        $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '11:00',
+                'new_clock_out' => '19:00',
+                'new_break_in' => ['12:00'],
+                'new_break_out' => ['13:00'],
+                'comment' => '承認済み申請テスト2',
+            ]
+        )->assertRedirect();
+
+        $admin = User::factory()->create([
+            'admin_status' => true,
+        ]);
+
+        $this->actingAs($admin);
+
+        $this->post(
+            '/stamp_correction_request/approve/'.$request1->id
+        )->assertRedirect();
+
+        $this->post(
+            '/stamp_correction_request/approve/'.$request2->id
+        )->assertRedirect();
+
+        $this->actingAs($user);
+
+        $response = $this->get(
+            '/stamp_correction_request/list?status=approved'
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee('承認済み申請テスト1');
+        $response->assertSee('承認済み申請テスト2');
+
+        $response->assertSee('10:00');
+        $response->assertSee('18:00');
+        $response->assertSee('11:00');
+        $response->assertSee('19:00');
+    }
+
+    /**
+     * 修正申請を作成する
+     */
+    private function createCorrectionRequest(
+        User $user,
+        AttendanceRecord $attendanceRecord,
+        string $comment,
+        string $clockIn,
+        string $clockOut
+    ): AttendanceCorrectionRequest {
+        return AttendanceCorrectionRequest::factory()->create([
+            'user_id' => $user->id,
+            'attendance_record_id' => $attendanceRecord->id,
+            'approval_status' => AttendanceCorrectionRequest::STATUS_PENDING,
+            'comment' => $comment,
+            'new_clock_in' => $clockIn,
+            'new_clock_out' => $clockOut,
+        ]);
+    }
+}

--- a/tests/Feature/Attendance/AttendanceCorrectionRequestTest.php
+++ b/tests/Feature/Attendance/AttendanceCorrectionRequestTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceCorrectionRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 修正申請処理が実行され、
+     * 管理者の承認画面に申請内容が表示される
+     */
+    public function test_correction_request_is_created(): void
+    {
+        [$user, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '10:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['12:00'],
+                'new_break_out' => ['13:00'],
+                'comment' => '出勤時間を修正します',
+            ]
+        );
+
+        $response->assertRedirect();
+
+        $request = AttendanceCorrectionRequest::where(
+            'attendance_record_id',
+            $attendanceRecord->id
+        )->firstOrFail();
+
+        $this->assertDatabaseHas(
+            'attendance_correction_requests',
+            [
+                'user_id' => $user->id,
+                'attendance_record_id' => $attendanceRecord->id,
+                'approval_status' => AttendanceCorrectionRequest::STATUS_PENDING,
+                'comment' => '出勤時間を修正します',
+                'new_clock_in' => '10:00',
+                'new_clock_out' => '18:00',
+            ]
+        );
+
+        $admin = User::factory()->create([
+            'admin_status' => true,
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->get(
+            '/stamp_correction_request/approve/'.$request->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee('出勤時間を修正します');
+        $response->assertSee('10:00');
+        $response->assertSee('18:00');
+    }
+
+    /**
+     * 申請の詳細から勤怠詳細画面へ遷移できる
+     */
+    public function test_can_navigate_to_attendance_detail_from_request(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '10:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['12:00'],
+                'new_break_out' => ['13:00'],
+                'comment' => '詳細画面遷移テスト',
+            ]
+        );
+
+        $response->assertRedirect();
+
+        $response = $this->get('/stamp_correction_request/list');
+
+        $response->assertStatus(200);
+        $response->assertSee('詳細画面遷移テスト');
+
+        $response->assertSee(
+            '/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response = $this->get(
+            '/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee('勤怠詳細');
+    }
+}

--- a/tests/Feature/Attendance/AttendanceCorrectionValidationTest.php
+++ b/tests/Feature/Attendance/AttendanceCorrectionValidationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceCorrectionValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 出勤時間が退勤時間より後の場合、
+     * エラーメッセージが表示される
+     */
+    public function test_clock_in_after_clock_out_shows_error(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '19:00',
+                'new_clock_out' => '18:00',
+                'comment' => '修正申請',
+            ]
+        );
+
+        $response->assertSessionHasErrors([
+            'new_clock_in' => '出勤時間もしくは退勤時間が不適切な値です。',
+        ]);
+    }
+
+    /**
+     * 休憩開始時間が退勤時間より後の場合、
+     * エラーメッセージが表示される
+     */
+    public function test_break_in_after_clock_out_shows_error(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '09:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['19:00'],
+                'new_break_out' => ['19:30'],
+                'comment' => '休憩時間を修正',
+            ]
+        );
+
+        $response->assertSessionHas(
+            'errors',
+            fn ($errors) => $errors->has('new_break_in.0')
+                && $errors->first('new_break_in.0')
+                    === '休憩時間が不適切な値です。'
+        );
+    }
+
+    /**
+     * 休憩終了時間が退勤時間より後の場合、
+     * エラーメッセージが表示される
+     */
+    public function test_break_out_after_clock_out_shows_error(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '09:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['17:00'],
+                'new_break_out' => ['19:00'],
+                'comment' => '休憩時間を修正',
+            ]
+        );
+
+        $response->assertSessionHas(
+            'errors',
+            fn ($errors) => $errors->has('new_break_out.0')
+                && $errors->first('new_break_out.0')
+                    === '休憩時間もしくは退勤時間が不適切な値です。'
+        );
+    }
+
+    /**
+     * 備考欄が未入力の場合、
+     * エラーメッセージが表示される
+     */
+    public function test_comment_required(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->post(
+            '/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '09:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => [''],
+                'new_break_out' => [''],
+                'comment' => '',
+            ]
+        );
+
+        $response->assertSessionHasErrors([
+            'comment' => '備考を記入してください。',
+        ]);
+    }
+}

--- a/tests/Feature/Attendance/AttendanceDetailTest.php
+++ b/tests/Feature/Attendance/AttendanceDetailTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Models\AttendanceBreak;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceDetailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 勤怠詳細画面の名前がログインユーザーの氏名になっている
+     */
+    public function test_user_name_is_displayed(): void
+    {
+        [$user, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->get(
+            '/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee($user->name);
+    }
+
+    /**
+     * 勤怠詳細画面の日付が選択した日付になっている
+     */
+    public function test_attendance_date_is_displayed(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->get(
+            '/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee(
+            date('Y', strtotime($attendanceRecord->date))
+        );
+        $response->assertSee(
+            date('m/d', strtotime($attendanceRecord->date))
+        );
+    }
+
+    /**
+     * 出勤・退勤時間がログインユーザーの打刻と一致している
+     */
+    public function test_clock_in_and_out_times_are_displayed(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $attendanceRecord->update([
+            'clock_out' => '18:00:00',
+        ]);
+
+        $response = $this->get(
+            '/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+    }
+
+    /**
+     * 休憩時間がログインユーザーの打刻と一致している
+     */
+    public function test_break_times_are_displayed(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        AttendanceBreak::factory()->create([
+            'attendance_record_id' => $attendanceRecord->id,
+            'break_in' => '12:00:00',
+            'break_out' => '13:00:00',
+        ]);
+
+        $response = $this->get(
+            '/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee('12:00');
+        $response->assertSee('13:00');
+    }
+}

--- a/tests/Feature/Attendance/AttendanceListTest.php
+++ b/tests/Feature/Attendance/AttendanceListTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 自分の勤怠情報が全て表示される
+     */
+    public function test_user_can_see_all_own_attendance_records(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfMonth()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfMonth()->addDays(1)->toDateString(),
+            'clock_in' => '10:00:00',
+            'clock_out' => '19:00:00',
+        ]);
+
+        $response = $this->get('/attendance/list');
+
+        $response->assertStatus(200);
+
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+        $response->assertSee('10:00');
+        $response->assertSee('19:00');
+    }
+
+    /**
+     * 現在の月が表示される
+     */
+    public function test_current_month_is_displayed(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->get('/attendance/list');
+
+        $response->assertStatus(200);
+        $response->assertSee(now()->format('Y/m'));
+    }
+
+    /**
+     * 前月の情報が表示される
+     */
+    public function test_previous_month_is_displayed(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $previousMonth = now()->subMonth();
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => $previousMonth->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        $response = $this->get(
+            '/attendance/list?date='.$previousMonth->format('Y-m')
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee($previousMonth->format('Y/m'));
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+    }
+
+    /**
+     * 翌月の情報が表示される
+     */
+    public function test_next_month_is_displayed(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $nextMonth = now()->addMonth();
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => $nextMonth->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        $response = $this->get('/attendance/list?date='.$nextMonth->format('Y-m'));
+
+        $response->assertStatus(200);
+        $response->assertSee($nextMonth->format('Y/m'));
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+    }
+
+    /**
+     * 詳細ボタンからその日の勤怠詳細画面へ遷移できる
+     */
+    public function test_user_can_navigate_to_attendance_detail(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $response = $this->get('/attendance/list');
+
+        $response->assertStatus(200);
+
+        $response = $this->get(
+            '/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Attendance/AttendanceStatusTest.php
+++ b/tests/Feature/Attendance/AttendanceStatusTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Attendance;
+
+use App\Models\AttendanceBreak;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AttendanceStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 現在の日時情報がUIと同じ形式で表示される
+     */
+    public function test_current_datetime_is_displayed(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee(now()->format('Y年m月d日'));
+        $response->assertSee(now()->format('H:i'));
+    }
+
+    /**
+     * 勤務外の場合、勤怠ステータスが正しく表示される
+     */
+    public function test_status_is_off_duty(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('勤務外');
+    }
+
+    /**
+     * 出勤中の場合、勤怠ステータスが正しく表示される
+     */
+    public function test_status_is_working(): void
+    {
+        $this->createAttendanceUser();
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('出勤中');
+    }
+
+    /**
+     * 休憩中の場合、勤怠ステータスが正しく表示される
+     */
+    public function test_status_is_on_break(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        AttendanceBreak::factory()->create([
+            'attendance_record_id' => $attendanceRecord->id,
+            'break_in' => '12:00:00',
+            'break_out' => null,
+        ]);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('休憩中');
+    }
+
+    /**
+     * 退勤済の場合、勤怠ステータスが正しく表示される
+     */
+    public function test_status_is_finished(): void
+    {
+        [, $attendanceRecord] = $this->createAttendanceUser();
+
+        $attendanceRecord->update([
+            'clock_out' => '18:00:00',
+        ]);
+
+        $response = $this->get('/attendance');
+
+        $response->assertStatus(200);
+        $response->assertSee('退勤済');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,27 @@
 
 namespace Tests;
 
+use App\Models\AttendanceRecord;
+use App\Models\User;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function createAttendanceUser(): array
+    {
+        $user = User::factory()->create();
+
+        $attendanceRecord = AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => null,
+        ]);
+
+        $this->actingAs($user);
+
+        return [$user, $attendanceRecord];
+    }
 }


### PR DESCRIPTION
## 概要

一般ユーザーの勤怠機能に対するFeatureテストを実装しました。

## 変更内容

- 勤怠ステータス・日時表示のFeatureテストを作成
- 勤怠打刻のFeatureテストを作成
- 休憩打刻のFeatureテストを作成
- 勤怠一覧のFeatureテストを作成
- 勤怠詳細のFeatureテストを作成
- 勤怠修正申請のFeatureテストを作成
- UserFactory、AttendanceRecordFactory、AttendanceBreakFactory、AttendanceCorrectionRequestFactory を利用してテストデータを作成

# テスト項目
- AttendanceStatusTest（5テスト：正常系5）
- AttendanceClockTest（5テスト：正常系4・異常系1）
- AttendanceBreakTest（5テスト：正常系5）
- AttendanceListTest（5テスト：正常系5）
- AttendanceDetailTest（4テスト：正常系4）
- AttendanceCorrectionListTest（2テスト：正常系2）
- AttendanceCorrectionRequestTest（2テスト：正常系2）
- AttendanceCorrectionValidationTest（4テスト：異常系4）

下記テストの確認は管理者申請機能#16、管理者申請一覧機能#17を実装後確認します。
- 修正申請処理が実行される
- 「承認済み」に管理者が承認した修正申請が全て表示されている
- 各申請の「詳細」を押下すると勤怠詳細画面に遷移する