### PR TITLE
feat: 管理者勤怠詳細・修正機能 #13

### DIFF
--- a/app/Http/Controllers/AdminAttendanceController.php
+++ b/app/Http/Controllers/AdminAttendanceController.php
@@ -2,9 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\AttendanceCorrectionRequest as AttendanceCorrectionRequestForm;
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
 use App\Services\AdminAttendanceService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class AdminAttendanceController extends Controller
 {
@@ -44,5 +48,96 @@ class AdminAttendanceController extends Controller
             'users',
             'attendanceRecords'
         ));
+    }
+
+    /**
+     * 管理者の勤怠詳細画面を表示する。
+     */
+    public function show(int $id)
+    {
+        $loginUser = Auth::user();
+
+        $attendanceRecord = AttendanceRecord::with([
+            'breaks',
+            'correctionRequests',
+            'user',
+        ])->findOrFail($id);
+
+        // 勤怠対象ユーザー
+        $user = $attendanceRecord->user;
+
+        $data = [
+            'id' => $attendanceRecord->id,
+
+            'application' => $attendanceRecord->correctionRequests
+                ->where(
+                    'approval_status',
+                    AttendanceCorrectionRequest::STATUS_PENDING
+                )
+                ->first(),
+
+            'year' => Carbon::parse($attendanceRecord->date)->format('Y'),
+
+            'date' => Carbon::parse($attendanceRecord->date)->format('m/d'),
+
+            'clock_in' => $attendanceRecord->clock_in
+                ? Carbon::parse($attendanceRecord->clock_in)->format('H:i')
+                : '',
+
+            'clock_out' => $attendanceRecord->clock_out
+                ? Carbon::parse($attendanceRecord->clock_out)->format('H:i')
+                : '',
+
+            'breaks' => $attendanceRecord->breaks->map(function ($break) {
+                return [
+                    'break_in' => $break->break_in
+                        ? Carbon::parse($break->break_in)->format('H:i')
+                        : '',
+
+                    'break_out' => $break->break_out
+                        ? Carbon::parse($break->break_out)->format('H:i')
+                        : '',
+                ];
+            })->values()->all(),
+
+            'comment' => $attendanceRecord->comment ?? '',
+        ];
+
+        return view('user.user-detail', compact(
+            'user',
+            'loginUser',
+            'data'
+        ));
+    }
+
+    /**
+     * 管理者が勤怠を直接修正する。
+     */
+    public function update(
+        AttendanceCorrectionRequestForm $request,
+        int $id
+    ) {
+        $attendanceRecord = AttendanceRecord::with('breaks')
+            ->findOrFail($id);
+
+        $attendanceRecord->update([
+            'clock_in' => $request->validated('new_clock_in'),
+            'clock_out' => $request->validated('new_clock_out'),
+            'comment' => $request->validated('comment'),
+        ]);
+
+        $breakIns = $request->validated('new_break_in', []);
+        $breakOuts = $request->validated('new_break_out', []);
+
+        foreach ($attendanceRecord->breaks as $index => $break) {
+            $break->update([
+                'break_in' => $breakIns[$index] ?? null,
+                'break_out' => $breakOuts[$index] ?? null,
+            ]);
+        }
+
+        return redirect()
+            ->route('admin.attendance.detail', $id)
+            ->with('success', '勤怠を修正しました。');
     }
 }

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -69,6 +69,7 @@ class AttendanceController extends Controller
      */
     public function index(Request $request)
     {
+        $loginUser = Auth::user();
         $user = Auth::user();
 
         $date = $request->filled('date')
@@ -96,7 +97,8 @@ class AttendanceController extends Controller
      */
     public function show(int $id)
     {
-        $user = Auth::user();
+        $loginUser = Auth::user();
+        $user = $loginUser;
 
         $attendanceRecord = AttendanceRecord::with([
             'breaks',
@@ -137,6 +139,7 @@ class AttendanceController extends Controller
 
         return view('user.user-detail', compact(
             'user',
+            'loginUser',
             'data'
         ));
     }

--- a/resources/views/admin/admin-attendance-list.blade.php
+++ b/resources/views/admin/admin-attendance-list.blade.php
@@ -57,7 +57,7 @@
                 <p class="table__description--item">{{ $attendance->total_time ? Carbon\Carbon::parse($attendance->total_time)->format('G:i') : '' }}</p>
             </td>
             <td class="table__description">
-                <a class="table__item--detail-link" href="{{ url('/attendance/' . $attendance['id']) }}">詳細</a>
+                <a class="table__item--detail-link" href="{{ url('/admin/attendance/detail/' . $attendance->id) }}">詳細</a>
             </td>
         </tr>
         @endif

--- a/resources/views/user/user-detail.blade.php
+++ b/resources/views/user/user-detail.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app')
+@extends(Auth::user()->admin_status ? 'layouts.admin-app' : 'layouts.app')
 
 @section('css')
     @vite('resources/css/user/user-detail.css')
@@ -9,7 +9,13 @@
         <div class="detail__header">
             <h1 class="content__header--item">勤怠詳細</h1>
         </div>
-        <form class="form" action="{{ url('/attendance/detail/' . $data['id']) }}" method="post">
+        <form
+            class="form"
+            action="{{ $loginUser->admin_status
+                ? route('admin.attendance.update', $data['id'])
+                : route('attendance.correction.store', $data['id']) }}"
+            method="post"
+        >
             @csrf
 
             @if (is_null($data['application']))

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,4 +90,16 @@ Route::middleware(['auth', 'admin'])->group(function () {
         '/admin/attendance/list',
         [AdminAttendanceController::class, 'index']
     )->name('admin.attendance.list');
+
+    // 管理者勤怠詳細
+    Route::get(
+        '/admin/attendance/detail/{id}',
+        [AdminAttendanceController::class, 'show']
+    )->name('admin.attendance.detail');
+
+    // 管理者勤怠修正
+    Route::post(
+        '/admin/attendance/detail/{id}',
+        [AdminAttendanceController::class, 'update']
+    )->name('admin.attendance.update');
 });


### PR DESCRIPTION
## 概要

管理者がスタッフの勤怠詳細を確認し、勤怠情報を修正できる、管理者向け勤怠詳細・修正機能を実装しました。

## 実装内容

- 管理者向け勤怠詳細画面を実装
- 指定したスタッフの勤怠詳細情報を取得・表示
- 名前、日付、出勤・退勤時間を表示
- 休憩時間を表示
- 備考を表示
- 勤怠詳細画面から出勤・退勤時間を編集できるよう実装
- 勤怠詳細画面から休憩時間を編集できるよう実装
- 勤怠詳細画面から備考を編集できるよう実装
- バリデーションエラーメッセージを表示
- 管理者の修正は承認処理を介さず直接保存
- 管理者用勤怠詳細URLを追加
- 管理者認証によるアクセス制御

## 動作確認

- [ 管理者用勤怠詳細画面が表示される
- [ ] スタッフの名前が正しく表示される
- [ ] 勤怠の日付が正しく表示される
- [ ] 出勤時間が正しく表示される
- [ ] 退勤時間が正しく表示される
- [ ] 休憩時間が正しく表示される
- [ ] 備考が正しく表示される
- [ ] 出勤・退勤時間を編集できる
- [ ] 休憩時間を編集できる
- [ ] 備考を編集できる
- [ ] 出勤時間が退勤時間より後の場合、エラーメッセージが表示される
- [ ] 休憩時間が出勤・退勤時間の範囲外の場合、エラーメッセージが表示される
- [ ] 休憩終了時間が休憩開始時間より前の場合、エラーメッセージが表示される
- [ ] 備考が未入力の場合、エラーメッセージが表示される
- [ ] 管理者が修正した勤怠情報を承認なしで保存できる
- [ ] 承認待ちの申請がある勤怠は修正できない
- [ ] 「承認待ちのため修正はできません。」と表示される
- [ ] 管理者勤怠一覧の「詳細」から勤怠詳細画面へ遷移できる
- [ ] 管理者以外は管理者用勤怠詳細画面にアクセスできない

## 対応Issue

close #13