### PR TITLE
feat: 管理者スタッフ一覧機能 #14

### DIFF
--- a/app/Http/Controllers/AdminStaffController.php
+++ b/app/Http/Controllers/AdminStaffController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+
+class AdminStaffController extends Controller
+{
+    /**
+     * スタッフ一覧画面を表示する。
+     */
+    public function index()
+    {
+        $users = User::where('admin_status', false)
+            ->get();
+
+        return view('admin.staff-list', compact('users'));
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AdminAttendanceController;
 use App\Http\Controllers\AdminLoginController;
 use App\Http\Controllers\AdminLogoutController;
+use App\Http\Controllers\AdminStaffController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\AttendanceCorrectionRequestController;
 use App\Http\Controllers\LoginController;
@@ -102,4 +103,10 @@ Route::middleware(['auth', 'admin'])->group(function () {
         '/admin/attendance/detail/{id}',
         [AdminAttendanceController::class, 'update']
     )->name('admin.attendance.update');
+
+    // 管理者スタッフ一覧画面
+    Route::get(
+        '/admin/staff/list',
+        [AdminStaffController::class, 'index']
+    )->name('admin.staff.list');
 });


### PR DESCRIPTION
## 概要

管理者がスタッフ一覧を確認し、各スタッフの月次勤怠画面へ遷移できる、管理者向けスタッフ一覧機能を実装しました。

## 実装内容
- 管理者向けスタッフ一覧画面を実装
- 一般ユーザーのユーザー情報を取得・表示
- スタッフの氏名を表示
- スタッフのメールアドレスを表示
- 各スタッフの月次勤怠画面への「詳細」リンクを表示
- 管理者認証によるアクセス制御

## 動作確認

- [ ] スタッフ一覧（管理者用）が表示される
- [ ] 一般ユーザーのスタッフ情報を取得できる
- [ ] スタッフの氏名が正しく表示される
- [ ] スタッフのメールアドレスが正しく表示される
- [ ] 管理者ユーザーがスタッフ一覧に表示されない
- [ ] 「詳細」リンクが表示される
- [ ] 「詳細」からスタッフ別月次勤怠画面のURLへ遷移できる
- [ ] 管理者以外はスタッフ一覧にアクセスできない

## 対応Issue

close #14
