### PR TITLE
feat: スタッフ別月次勤怠一覧機能 #15

### DIFF
--- a/app/Http/Controllers/AdminAttendanceController.php
+++ b/app/Http/Controllers/AdminAttendanceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\AttendanceCorrectionRequest as AttendanceCorrectionRequestForm;
 use App\Models\AttendanceCorrectionRequest;
 use App\Models\AttendanceRecord;
+use App\Models\User;
 use App\Services\AdminAttendanceService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -139,5 +140,39 @@ class AdminAttendanceController extends Controller
         return redirect()
             ->route('admin.attendance.detail', $id)
             ->with('success', '勤怠を修正しました。');
+    }
+
+    /**
+     * スタッフ別月次勤怠一覧画面を表示する。
+     */
+    public function staff(Request $request, int $id)
+    {
+        $user = User::findOrFail($id);
+
+        $date = $request->filled('date')
+            ? Carbon::createFromFormat('Y-m', $request->input('date'))
+            : now()->startOfMonth();
+
+        $formattedAttendanceRecords =
+            $this->adminAttendanceService->getStaffMonthlyRecords(
+                $user,
+                $date
+            );
+
+        $previousMonth = $date->copy()
+            ->subMonth()
+            ->format('Y-m');
+
+        $nextMonth = $date->copy()
+            ->addMonth()
+            ->format('Y-m');
+
+        return view('admin.staff-attendance-list', compact(
+            'user',
+            'date',
+            'previousMonth',
+            'nextMonth',
+            'formattedAttendanceRecords'
+        ));
     }
 }

--- a/app/Services/AdminAttendanceService.php
+++ b/app/Services/AdminAttendanceService.php
@@ -95,4 +95,68 @@ class AdminAttendanceService
 
         return gmdate('H:i:s', $workSeconds);
     }
+
+    /**
+     * 指定ユーザーの月次勤怠記録を取得する。
+     */
+    public function getStaffMonthlyRecords(
+        User $user,
+        Carbon $date
+    ): Collection {
+        $startOfMonth = $date->copy()->startOfMonth();
+        $endOfMonth = $date->copy()->endOfMonth();
+
+        $attendanceRecords = AttendanceRecord::with('breaks')
+            ->where('user_id', $user->id)
+            ->whereBetween('date', [
+                $startOfMonth->toDateString(),
+                $endOfMonth->toDateString(),
+            ])
+            ->get()
+            ->keyBy(function ($attendanceRecord) {
+                return Carbon::parse($attendanceRecord->date)
+                    ->format('Y-m-d');
+            });
+
+        $formattedRecords = collect();
+
+        for (
+            $currentDate = $startOfMonth->copy();
+            $currentDate->lte($endOfMonth);
+            $currentDate->addDay()
+        ) {
+            $attendanceRecord = $attendanceRecords->get(
+                $currentDate->format('Y-m-d')
+            );
+
+            if ($attendanceRecord) {
+                $totalBreakTime = $this->calculateTotalBreakTime(
+                    $attendanceRecord
+                );
+
+                $totalWorkTime = $this->calculateTotalWorkTime(
+                    $attendanceRecord,
+                    $totalBreakTime
+                );
+
+                $attendanceRecord->total_break_time = $totalBreakTime;
+                $attendanceRecord->total_time = $totalWorkTime;
+            }
+
+            $formattedRecords->push([
+                'id' => $attendanceRecord?->id,
+                'date' => $currentDate->format('m/d'),
+                'clock_in' => $attendanceRecord?->clock_in
+                    ? Carbon::parse($attendanceRecord->clock_in)->format('H:i')
+                    : '',
+                'clock_out' => $attendanceRecord?->clock_out
+                    ? Carbon::parse($attendanceRecord->clock_out)->format('H:i')
+                    : '',
+                'total_break_time' => $attendanceRecord?->total_break_time,
+                'total_time' => $attendanceRecord?->total_time,
+            ]);
+        }
+
+        return $formattedRecords;
+    }
 }

--- a/resources/views/admin/staff-attendance-list.blade.php
+++ b/resources/views/admin/staff-attendance-list.blade.php
@@ -54,7 +54,7 @@
             </td>
             <td class="table__description">
                 @if (!empty($attendanceRecords['id']))
-                <a class="table__item--detail-link" href="{{ url('/attendance/' . $attendanceRecords['id']) }}">詳細</a>
+                <a class="table__item--detail-link" href="{{ url('/admin/attendance/detail/' . $attendanceRecords['id']) }}">詳細</a>
                 @endif
             </td>
         </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -109,4 +109,10 @@ Route::middleware(['auth', 'admin'])->group(function () {
         '/admin/staff/list',
         [AdminStaffController::class, 'index']
     )->name('admin.staff.list');
+
+    // スタッフ別月次勤怠一覧
+    Route::get(
+        '/admin/attendance/staff/{id}',
+        [AdminAttendanceController::class, 'staff']
+    )->name('admin.attendance.staff');
 });


### PR DESCRIPTION
## 概要

管理者がスタッフごとの月次勤怠情報を確認できる、スタッフ別月次勤怠一覧機能を実装しました。

## 実装内容

- スタッフを指定した月次勤怠一覧画面を実装
- 指定したスタッフの勤怠情報を取得・表示
- 出勤・退勤時間を表示
- 休憩時間の合計を表示
- 実働時間の合計を表示
- 勤怠情報がない日は空白で表示
- 現在の月を初期表示
- 「前月」「翌月」による月表示変更機能を実装
- 各勤怠の「詳細」から勤怠詳細画面へ遷移できるよう実装
- 管理者認証によるアクセス制御
- スタッフ別月次勤怠の取得・計算処理を `AdminAttendanceService` に追加

## 動作確認

- [ ] スタッフ別月次勤怠一覧が表示される
- [ ] 指定したスタッフの勤怠情報を取得できる
- [ ] 出勤時間が正しく表示される
- [ ] 退勤時間が正しく表示される
- [ ] 勤怠情報がない項目が空白で表示される
- [ ] 休憩時間が正しく表示される
- [ ] 実働時間が正しく表示される
- [ ] 遷移時に現在の月が表示される
- [ ] 「前月」を押すと前月の勤怠一覧が表示される
- [ ] 「翌月」を押すと翌月の勤怠一覧が表示される
- [ ] 「詳細」から勤怠詳細画面へ遷移できる
- [ ] 管理者以外はスタッフ別月次勤怠一覧にアクセスできない

## 対応Issue

close #15