### PR TITLE
test: 管理者勤怠機能テスト #20

### DIFF
--- a/tests/Feature/AdminAttendanceDetailTest.php
+++ b/tests/Feature/AdminAttendanceDetailTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AttendanceBreak;
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminAttendanceDetailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 一般ユーザーと勤怠レコードを作成する。
+     */
+    private function createAttendanceRecord(): array
+    {
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $attendanceRecord = AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+            'comment' => '通常勤務',
+        ]);
+
+        return [$user, $attendanceRecord];
+    }
+
+    /**
+     * 休憩情報を作成する。
+     */
+    private function createBreak(AttendanceRecord $attendanceRecord): void
+    {
+        AttendanceBreak::factory()->create([
+            'attendance_record_id' => $attendanceRecord->id,
+            'break_in' => '12:00:00',
+            'break_out' => '13:00:00',
+        ]);
+    }
+
+    /**
+     * 管理者が選択した勤怠詳細を確認できる
+     */
+    public function test_admin_can_see_selected_attendance_detail(): void
+    {
+        $this->createAdminUser();
+        [$user, $attendanceRecord] = $this->createAttendanceRecord();
+
+        $response = $this->get(
+            '/admin/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+        $response->assertSee($user->name);
+        $response->assertSee(now()->format('m/d'));
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+        $response->assertSee('通常勤務');
+    }
+
+    /**
+     * 出勤時間が退勤時間より後の場合、エラーになる
+     */
+    public function test_clock_in_after_clock_out_shows_error(): void
+    {
+        $this->createAdminUser();
+        [, $attendanceRecord] = $this->createAttendanceRecord();
+
+        $response = $this->get(
+            '/admin/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+
+        $response = $this->post(
+            '/admin/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '19:00',
+                'new_clock_out' => '18:00',
+                'comment' => '勤務時間を修正',
+            ]
+        );
+
+        $response->assertSessionHasErrors([
+            'new_clock_in' => '出勤時間もしくは退勤時間が不適切な値です。',
+        ]);
+    }
+
+    /**
+     * 休憩開始時間が退勤時間より後の場合、エラーになる
+     */
+    public function test_break_in_after_clock_out_shows_error(): void
+    {
+        $this->createAdminUser();
+        [, $attendanceRecord] = $this->createAttendanceRecord();
+
+        $this->createBreak($attendanceRecord);
+
+        $response = $this->get(
+            '/admin/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+
+        $response = $this->post(
+            '/admin/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '09:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['19:00'],
+                'new_break_out' => ['20:00'],
+                'comment' => '休憩時間を修正',
+            ]
+        );
+
+        $response->assertSessionHasErrors([
+            'new_break_in.0' => '休憩時間が不適切な値です。',
+        ]);
+    }
+
+    /**
+     * 休憩終了時間が退勤時間より後の場合、エラーになる
+     */
+    public function test_break_out_after_clock_out_shows_error(): void
+    {
+        $this->createAdminUser();
+        [, $attendanceRecord] = $this->createAttendanceRecord();
+
+        $this->createBreak($attendanceRecord);
+
+        $response = $this->get(
+            '/admin/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+
+        $response = $this->post(
+            '/admin/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '09:00',
+                'new_clock_out' => '18:00',
+                'new_break_in' => ['12:00'],
+                'new_break_out' => ['19:00'],
+                'comment' => '休憩時間を修正',
+            ]
+        );
+
+        $response->assertSessionHasErrors([
+            'new_break_out.0' => '休憩時間もしくは退勤時間が不適切な値です。',
+        ]);
+    }
+
+    /**
+     * 備考が未入力の場合、エラーになる
+     */
+    public function test_comment_required(): void
+    {
+        $this->createAdminUser();
+        [, $attendanceRecord] = $this->createAttendanceRecord();
+
+        $response = $this->get(
+            '/admin/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertStatus(200);
+
+        $response = $this->post(
+            '/admin/attendance/detail/'.$attendanceRecord->id,
+            [
+                'new_clock_in' => '09:00',
+                'new_clock_out' => '18:00',
+                'comment' => '',
+            ]
+        );
+
+        $response->assertSessionHasErrors([
+            'comment' => '備考を記入してください。',
+        ]);
+    }
+
+    /**
+     * 管理者以外は管理者勤怠詳細にアクセスできない
+     */
+    public function test_general_user_cannot_access_admin_attendance_detail(): void
+    {
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $attendanceRecord = AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->get(
+            '/admin/attendance/detail/'.$attendanceRecord->id
+        );
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/AdminAttendanceListTest.php
+++ b/tests/Feature/AdminAttendanceListTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminAttendanceListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 管理者がその日の全ユーザーの勤怠情報を確認できる
+     */
+    public function test_admin_can_see_all_users_attendance_records(): void
+    {
+        $admin = $this->createAdminUser();
+
+        $user1 = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $user2 = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        // 管理者の勤怠
+        AttendanceRecord::factory()->create([
+            'user_id' => $admin->id,
+            'date' => now()->toDateString(),
+            'clock_in' => '08:00:00',
+            'clock_out' => '17:00:00',
+        ]);
+
+        // 一般ユーザー1の勤怠
+        AttendanceRecord::factory()->create([
+            'user_id' => $user1->id,
+            'date' => now()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        // 一般ユーザー2の勤怠
+        AttendanceRecord::factory()->create([
+            'user_id' => $user2->id,
+            'date' => now()->toDateString(),
+            'clock_in' => '10:00:00',
+            'clock_out' => '19:00:00',
+        ]);
+
+        $response = $this->get('/admin/attendance/list');
+
+        $response->assertStatus(200);
+
+        // 全ユーザーが表示されること
+        $response->assertSee($admin->name);
+        $response->assertSee($user1->name);
+        $response->assertSee($user2->name);
+
+        // 勤怠時間が表示されること
+        $response->assertSee('08:00');
+        $response->assertSee('17:00');
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+        $response->assertSee('10:00');
+        $response->assertSee('19:00');
+    }
+
+    /**
+     * 勤怠一覧画面を開いたとき現在の日付が表示される
+     */
+    public function test_current_date_is_displayed(): void
+    {
+        $this->createAdminUser();
+
+        $response = $this->get('/admin/attendance/list');
+
+        $response->assertStatus(200);
+        $response->assertSee(now()->format('Y/m/d'));
+    }
+
+    /**
+     * 前日の勤怠情報が表示される
+     */
+    public function test_previous_day_is_displayed(): void
+    {
+        $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $previousDay = now()->subDay();
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => $previousDay->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/list?date='.$previousDay->format('Y-m-d')
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee($previousDay->format('Y/m/d'));
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+    }
+
+    /**
+     * 翌日の勤怠情報が表示される
+     */
+    public function test_next_day_is_displayed(): void
+    {
+        $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $nextDay = now()->addDay();
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => $nextDay->toDateString(),
+            'clock_in' => '10:00:00',
+            'clock_out' => '19:00:00',
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/list?date='.$nextDay->format('Y-m-d')
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee($nextDay->format('Y/m/d'));
+        $response->assertSee('10:00');
+        $response->assertSee('19:00');
+    }
+
+    /**
+     * 一般ユーザーは管理者勤怠一覧にアクセスできない
+     */
+    public function test_general_user_cannot_access_admin_attendance_list(): void
+    {
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->get('/admin/attendance/list');
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/AdminStaffAttendanceTest.php
+++ b/tests/Feature/AdminStaffAttendanceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminStaffAttendanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 管理者が選択したユーザーの勤怠情報を確認できる
+     */
+    public function test_admin_can_see_selected_user_attendance_records(): void
+    {
+        $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'name' => '一般ユーザー',
+            'admin_status' => false,
+        ]);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfMonth()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfMonth()->addDay()->toDateString(),
+            'clock_in' => '10:00:00',
+            'clock_out' => '19:00:00',
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/staff/'.$user->id
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee($user->name);
+
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+
+        $response->assertSee('10:00');
+        $response->assertSee('19:00');
+    }
+
+    /**
+     * 現在の月が表示される
+     */
+    public function test_current_month_is_displayed(): void
+    {
+        $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/staff/'.$user->id
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee(
+            now()->format('Y/m')
+        );
+    }
+
+    /**
+     * 前月の勤怠情報が表示される
+     */
+    public function test_previous_month_is_displayed(): void
+    {
+        $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $previousMonth = now()->subMonth();
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => $previousMonth->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/staff/'.$user->id.
+            '?date='.$previousMonth->format('Y-m')
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee(
+            $previousMonth->format('Y/m')
+        );
+
+        $response->assertSee('09:00');
+        $response->assertSee('18:00');
+    }
+
+    /**
+     * 翌月の勤怠情報が表示される
+     */
+    public function test_next_month_is_displayed(): void
+    {
+        $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $nextMonth = now()->addMonth();
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => $nextMonth->toDateString(),
+            'clock_in' => '10:00:00',
+            'clock_out' => '19:00:00',
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/staff/'.$user->id.
+            '?date='.$nextMonth->format('Y-m')
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee(
+            $nextMonth->format('Y/m')
+        );
+
+        $response->assertSee('10:00');
+        $response->assertSee('19:00');
+    }
+
+    /**
+     * 詳細ボタンからその日の勤怠詳細画面へ遷移できる
+     */
+    public function test_admin_can_navigate_to_attendance_detail(): void
+    {
+        $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $attendanceRecord = AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/staff/'.$user->id
+        );
+
+        $response->assertStatus(200);
+
+        $response->assertSee(
+            '/admin/attendance/detail/'.$attendanceRecord->id
+        );
+    }
+
+    /**
+     * 一般ユーザーはスタッフ別勤怠一覧にアクセスできない
+     */
+    public function test_general_user_cannot_access_admin_staff_attendance(): void
+    {
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $this->actingAs($user);
+
+        $targetUser = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $response = $this->get(
+            '/admin/attendance/staff/'.$targetUser->id
+        );
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Feature/AdminStaffListTest.php
+++ b/tests/Feature/AdminStaffListTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminStaffListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * 管理者が全一般ユーザーの氏名を確認できる
+     */
+    public function test_admin_can_see_all_general_users_names(): void
+    {
+        $this->createAdminUser();
+
+        $user1 = User::factory()->create([
+            'name' => '一般ユーザー1',
+            'email' => 'user1@example.com',
+            'admin_status' => false,
+        ]);
+
+        $user2 = User::factory()->create([
+            'name' => '一般ユーザー2',
+            'email' => 'user2@example.com',
+            'admin_status' => false,
+        ]);
+
+        $response = $this->get('/admin/staff/list');
+
+        $response->assertStatus(200);
+
+        $response->assertSee($user1->name);
+        $response->assertSee($user2->name);
+    }
+
+    /**
+     * 管理者が全一般ユーザーのメールアドレスを確認できる
+     */
+    public function test_admin_can_see_all_general_users_emails(): void
+    {
+        $this->createAdminUser();
+
+        $user1 = User::factory()->create([
+            'name' => '一般ユーザー1',
+            'email' => 'user1@example.com',
+            'admin_status' => false,
+        ]);
+
+        $user2 = User::factory()->create([
+            'name' => '一般ユーザー2',
+            'email' => 'user2@example.com',
+            'admin_status' => false,
+        ]);
+
+        $response = $this->get('/admin/staff/list');
+
+        $response->assertStatus(200);
+
+        $response->assertSee($user1->email);
+        $response->assertSee($user2->email);
+    }
+
+    /**
+     * 管理者はスタッフ一覧に表示されない
+     */
+    public function test_admin_is_not_displayed_in_staff_list(): void
+    {
+        $admin = $this->createAdminUser();
+
+        $user = User::factory()->create([
+            'name' => '一般ユーザー',
+            'email' => 'user@example.com',
+            'admin_status' => false,
+        ]);
+
+        $response = $this->get('/admin/staff/list');
+
+        $response->assertStatus(200);
+
+        $response->assertSee($user->name);
+        $response->assertSee($user->email);
+
+        $response->assertDontSee($admin->name);
+        $response->assertDontSee($admin->email);
+    }
+
+    /**
+     * 一般ユーザーは管理者スタッフ一覧にアクセスできない
+     */
+    public function test_general_user_cannot_access_admin_staff_list(): void
+    {
+        User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $user = User::factory()->create([
+            'admin_status' => false,
+        ]);
+
+        $this->actingAs($user);
+
+        $response = $this->get('/admin/staff/list');
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,4 +25,18 @@ abstract class TestCase extends BaseTestCase
 
         return [$user, $attendanceRecord];
     }
+
+    /**
+     * 管理者ユーザーを作成してログインする。
+     */
+    protected function createAdminUser(): User
+    {
+        $admin = User::factory()->create([
+            'admin_status' => true,
+        ]);
+
+        $this->actingAs($admin);
+
+        return $admin;
+    }
 }


### PR DESCRIPTION
## 概要

管理者勤怠機能に対するFeatureテストを実装しました。

## 変更内容

- 管理者勤怠一覧のFeatureテストを作成
- 管理者がその日の全ユーザーの勤怠情報を確認できることをテスト
- 管理者の勤怠情報も一覧に表示されることをテスト
- 現在の日付が表示されることをテスト
- 前日の勤怠情報が表示されることをテスト
- 翌日の勤怠情報が表示されることをテスト
- 一般ユーザーが管理者勤怠一覧へアクセスできないことをテスト
- 管理者勤怠詳細のFeatureテストを作成
- 管理者が選択した勤怠詳細を確認できることをテスト
- 出勤・退勤時間の前後関係に関するバリデーションテストを追加
- 休憩時間の前後関係に関するバリデーションテストを追加
- 備考未入力時のバリデーションテストを追加
- 一般ユーザーが管理者勤怠詳細へアクセスできないことをテスト
- 管理者ユーザー作成・ログイン処理を共通化
- Factoryを利用してテストデータを作成

## テスト項目

- AdminAttendanceListTest（5テスト：正常系4・異常系1）
- AdminAttendanceDetailTest（6テスト：正常系1・異常系5）
- AdminStaffListTest（4テスト：正常系3・異常系1）
- AdminStaffAttendanceTest（6テスト：正常系5・異常系1）

## 対応Issue

close #20
