### PR TITLE
feat: 管理者申請一覧機能 #16

### DIFF
--- a/app/Http/Controllers/AdminAttendanceCorrectionRequestController.php
+++ b/app/Http/Controllers/AdminAttendanceCorrectionRequestController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\AdminAttendanceCorrectionRequestService;
+
+class AdminAttendanceCorrectionRequestController extends Controller
+{
+    public function __construct(
+        private AdminAttendanceCorrectionRequestService $adminAttendanceCorrectionRequestService
+    ) {}
+
+    /**
+     * 管理者の勤怠修正申請一覧画面を表示する。
+     */
+    public function index()
+    {
+        $applications = $this->adminAttendanceCorrectionRequestService
+            ->getApplications();
+
+        return view('admin.admin-application-list', compact(
+            'applications'
+        ));
+    }
+}

--- a/app/Http/Controllers/AttendanceCorrectionRequestListController.php
+++ b/app/Http/Controllers/AttendanceCorrectionRequestListController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AttendanceCorrectionRequestListController extends Controller
+{
+    /**
+     * 勤怠修正申請一覧画面を表示する。
+     */
+    public function index(Request $request)
+    {
+        if ($request->attributes->get('is_admin')) {
+            return app(AdminAttendanceCorrectionRequestController::class)
+                ->index();
+        }
+
+        return app(AttendanceCorrectionRequestController::class)
+            ->index();
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use App\Http\Middleware\AdminMiddleware;
+use App\Http\Middleware\AttendanceCorrectionRequestRoleMiddleware;
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
@@ -89,5 +90,6 @@ class Kernel extends HttpKernel
         'throttle' => ThrottleRequests::class,
         'verified' => EnsureEmailIsVerified::class,
         'admin' => AdminMiddleware::class,
+        'correction.request.role' => AttendanceCorrectionRequestRoleMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/AttendanceCorrectionRequestRoleMiddleware.php
+++ b/app/Http/Middleware/AttendanceCorrectionRequestRoleMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AttendanceCorrectionRequestRoleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(
+        Request $request,
+        Closure $next
+    ): Response {
+        $isAdmin = $request->user()?->admin_status === true;
+
+        $request->attributes->set('is_admin', $isAdmin);
+
+        return $next($request);
+    }
+}

--- a/app/Services/AdminAttendanceCorrectionRequestService.php
+++ b/app/Services/AdminAttendanceCorrectionRequestService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceCorrectionRequest;
+use Illuminate\Support\Collection;
+
+class AdminAttendanceCorrectionRequestService
+{
+    /**
+     * 全一般ユーザーの勤怠修正申請を取得する。
+     */
+    public function getApplications(): Collection
+    {
+        return AttendanceCorrectionRequest::with([
+            'user',
+            'attendanceRecord',
+        ])
+            ->whereHas('user', function ($query) {
+                $query->where('admin_status', false);
+            })
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function (AttendanceCorrectionRequest $application) {
+                return $this->formatApplication($application);
+            });
+    }
+
+    /**
+     * 管理者の申請一覧画面で使用する形式に整形する。
+     */
+    private function formatApplication(
+        AttendanceCorrectionRequest $application
+    ): AttendanceCorrectionRequest {
+        $application->approval_status =
+            $application->approval_status === AttendanceCorrectionRequest::STATUS_PENDING
+                ? '承認待ち'
+                : '承認済み';
+
+        $application->application_date =
+            $application->created_at->format('Y/m/d');
+
+        return $application;
+    }
+}

--- a/resources/views/admin/admin-application-list.blade.php
+++ b/resources/views/admin/admin-application-list.blade.php
@@ -46,7 +46,7 @@
                         <p class="table__description--item">{{ $application->user->name }}</p>
                     </td>
                     <td class="table__description">
-                        <p class="table__description--item">{{ \Carbon\Carbon::parse($application->AttendanceRecord->date)->format('Y/m/d') }}</p>
+                        <p class="table__description--item">{{ \Carbon\Carbon::parse($application->attendancerecord->date)->format('Y/m/d') }}</p>
                     </td>
                     <td class="table__description">
                         <p class="table__description--item">{{ $application->comment }}</p>
@@ -94,7 +94,7 @@
                         <p class="table__description--item">{{ $application->user->name }}</p>
                     </td>
                     <td class="table__description">
-                        <p class="table__description--item">{{ \Carbon\Carbon::parse($application->AttendanceRecord->date)->format('Y/m/d') }}</p>
+                        <p class="table__description--item">{{ \Carbon\Carbon::parse($application->attendancerecord->date)->format('Y/m/d') }}</p>
                     </td>
                     <td class="table__description">
                         <p class="table__description--item">{{ $application->comment }}</p>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\AdminLogoutController;
 use App\Http\Controllers\AdminStaffController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\AttendanceCorrectionRequestController;
+use App\Http\Controllers\AttendanceCorrectionRequestListController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\RegisterController;
 use Illuminate\Support\Facades\Route;
@@ -61,8 +62,10 @@ Route::middleware('auth')->group(function () {
     // 勤怠修正申請一覧画面
     Route::get(
         '/stamp_correction_request/list',
-        [AttendanceCorrectionRequestController::class, 'index']
-    )->name('attendance.correction.index');
+        [AttendanceCorrectionRequestListController::class, 'index']
+    )
+        ->middleware('correction.request.role')
+        ->name('attendance.correction.index');
 
     // 勤怠修正申請詳細画面
     Route::get(


### PR DESCRIPTION
## 概要

管理者がスタッフから提出された勤怠修正申請を確認できる、管理者申請一覧機能を実装しました。

## 実装内容

- 管理者用の勤怠修正申請一覧画面を実装
- 「承認待ち」「承認済み」に分けて申請情報を表示
- 全一般ユーザーの勤怠修正申請を取得・表示
- 申請者の名前を表示
- 対象日時を表示
- 申請理由を表示
- 申請日時を表示
- 各申請の「詳細」から申請詳細画面へ遷移できるよう実装
- 管理者と一般ユーザーで同じ `/stamp_correction_request/list` を使用
- `AttendanceCorrectionRequestRoleMiddleware` による管理者・一般ユーザーの振り分けを実装
- 管理者申請一覧の取得・表示処理を `AdminAttendanceCorrectionRequestService` に分離
- 管理者認証によるアクセス制御

## 動作確認

- [ ] 管理者が勤怠修正申請一覧を表示できる
- [ ] 承認待ち申請が表示される
- [ ] 承認済み申請が表示される
- [ ] 全一般ユーザーの申請が表示される
- [ ] 申請者の名前が正しく表示される
- [ ] 対象日時が正しく表示される
- [ ] 申請理由が正しく表示される
- [ ] 申請日時が正しく表示される
- [ ] 「詳細」から申請詳細画面（/stamp_correction_request/approve/{attendance_correct_request_id}）へ遷移できる
- [ ] 管理者と一般ユーザーが同じ `/stamp_correction_request/list` にアクセスできる
- [ ] 管理者の場合は管理者用申請一覧が表示される
- [ ] 一般ユーザーの場合は一般ユーザー用申請一覧が表示される
- [ ] 管理者以外は管理者用申請一覧の機能を利用できない

## 対応Issue

close #16