### PR TITLE
feat: 管理者修正申請承認機能 #17

### DIFF
--- a/app/Http/Controllers/AdminAttendanceCorrectionRequestController.php
+++ b/app/Http/Controllers/AdminAttendanceCorrectionRequestController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AttendanceCorrectionRequest;
 use App\Services\AdminAttendanceCorrectionRequestService;
 
 class AdminAttendanceCorrectionRequestController extends Controller
@@ -21,5 +22,36 @@ class AdminAttendanceCorrectionRequestController extends Controller
         return view('admin.admin-application-list', compact(
             'applications'
         ));
+    }
+
+    /**
+     * 管理者の勤怠修正申請詳細画面を表示する。
+     */
+    public function show(int $id)
+    {
+        $application = $this->adminAttendanceCorrectionRequestService
+            ->getApplication($id);
+
+        $application->approval_status =
+            $application->approval_status === AttendanceCorrectionRequest::STATUS_PENDING
+                ? '承認待ち'
+                : '承認済み';
+
+        return view('admin.admin-application-detail', [
+            'application' => $application,
+            'user' => $application->user,
+        ]);
+    }
+
+    /**
+     * 管理者が勤怠修正申請を承認する。
+     */
+    public function approve(int $id)
+    {
+        $this->adminAttendanceCorrectionRequestService
+            ->approve($id);
+
+        return redirect()
+            ->route('admin.attendance.correction.show', $id);
     }
 }

--- a/app/Models/AttendanceCorrectionRequest.php
+++ b/app/Models/AttendanceCorrectionRequest.php
@@ -25,6 +25,10 @@ class AttendanceCorrectionRequest extends Model
         'new_clock_out',
     ];
 
+    protected $casts = [
+        'new_date' => 'date',
+    ];
+
     // user_idを外部キーとしてUserモデルとのリレーションを定義
     public function user(): BelongsTo
     {

--- a/app/Services/AdminAttendanceCorrectionRequestService.php
+++ b/app/Services/AdminAttendanceCorrectionRequestService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\AttendanceBreak;
 use App\Models\AttendanceCorrectionRequest;
 use Illuminate\Support\Collection;
 
@@ -41,5 +42,55 @@ class AdminAttendanceCorrectionRequestService
             $application->created_at->format('Y/m/d');
 
         return $application;
+    }
+
+    /**
+     * 指定された勤怠修正申請の詳細を取得する。
+     */
+    public function getApplication(int $id): AttendanceCorrectionRequest
+    {
+        return AttendanceCorrectionRequest::with([
+            'user',
+            'attendanceRecord',
+            'proposalBreaks',
+        ])->findOrFail($id);
+    }
+
+    /**
+     * 勤怠修正申請を承認する。
+     */
+    public function approve(int $id): void
+    {
+        $application = AttendanceCorrectionRequest::with([
+            'attendanceRecord',
+            'proposalBreaks',
+        ])->findOrFail($id);
+
+        $attendanceRecord = $application->attendanceRecord;
+
+        // 勤怠情報を申請内容で更新
+        $attendanceRecord->update([
+            'date' => $application->new_date,
+            'clock_in' => $application->new_clock_in,
+            'clock_out' => $application->new_clock_out,
+            'comment' => $application->comment,
+        ]);
+
+        // 既存の休憩情報を削除
+        $attendanceRecord->breaks()->delete();
+
+        // 申請された休憩情報を勤怠に反映
+        foreach ($application->proposalBreaks as $proposalBreak) {
+            AttendanceBreak::create([
+                'attendance_record_id' => $attendanceRecord->id,
+                'break_in' => $proposalBreak->break_in,
+                'break_out' => $proposalBreak->break_out,
+            ]);
+        }
+
+        // 申請を承認済みに変更
+        $application->update([
+            'approval_status' => AttendanceCorrectionRequest::STATUS_APPROVED,
+        ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AdminAttendanceController;
+use App\Http\Controllers\AdminAttendanceCorrectionRequestController;
 use App\Http\Controllers\AdminLoginController;
 use App\Http\Controllers\AdminLogoutController;
 use App\Http\Controllers\AdminStaffController;
@@ -118,4 +119,16 @@ Route::middleware(['auth', 'admin'])->group(function () {
         '/admin/attendance/staff/{id}',
         [AdminAttendanceController::class, 'staff']
     )->name('admin.attendance.staff');
+
+    // 管理者勤怠修正申請詳細画面
+    Route::get(
+        '/stamp_correction_request/approve/{id}',
+        [AdminAttendanceCorrectionRequestController::class, 'show']
+    )->name('admin.attendance.correction.show');
+
+    // 管理者勤怠修正申請承認処理
+    Route::post(
+        '/stamp_correction_request/approve/{id}',
+        [AdminAttendanceCorrectionRequestController::class, 'approve']
+    )->name('admin.attendance.correction.approve');
 });


### PR DESCRIPTION
## 概要

管理者が一般ユーザーから提出された勤怠修正申請の詳細を確認し、承認できる管理者修正申請承認機能を実装しました。

## 実装内容

- 管理者用の勤怠修正申請詳細画面を実装
- 指定された勤怠修正申請の詳細情報を取得・表示
- 申請者の名前を表示
- 修正対象の日付を表示
- 修正後の出勤・退勤時間を表示
- 修正後の休憩時間を表示
- 申請理由を表示
- 「承認待ち」の申請に「承認」ボタンを表示
- 管理者が修正申請を承認できる機能を実装
- 承認後に申請状態を「承認済み」に変更
- 承認後に修正申請の内容を勤怠情報へ反映
- 承認済みの申請では「承認済み」と表示
- 管理者認証によるアクセス制御
- 勤怠修正申請の取得・承認処理を `AdminAttendanceCorrectionRequestService` に分離

## 動作確認

- [ ] 管理者が勤怠修正申請の詳細画面を表示できる
- [ ] 選択した申請の詳細情報が正しく表示される
- [ ] 申請者の名前が正しく表示される
- [ ] 修正対象の日付が正しく表示される
- [ ] 修正後の出勤時間が正しく表示される
- [ ] 修正後の退勤時間が正しく表示される
- [ ] 修正後の休憩時間が正しく表示される
- [ ] 申請理由が正しく表示される
- [ ] 承認待ちの申請に「承認」ボタンが表示される
- [ ] 「承認」を押すと申請状態が「承認済み」に変更される
- [ ] 承認後に管理者の申請一覧で「承認済み」に表示される
- [ ] 承認後に一般ユーザーの申請一覧で「承認済み」に表示される
- [ ] 承認内容が一般ユーザーの勤怠情報へ反映される
- [ ] 承認済みの申請では「承認済み」と表示される
- [ ] 管理者以外は修正申請の承認機能を利用できない

## 対応Issue

close #17
