### PR TITLE
fix: 管理者勤怠詳細画面の表示先を修正

### DIFF
--- a/app/Http/Controllers/AdminAttendanceController.php
+++ b/app/Http/Controllers/AdminAttendanceController.php
@@ -104,11 +104,11 @@ class AdminAttendanceController extends Controller
             'comment' => $attendanceRecord->comment ?? '',
         ];
 
-        return view('user.user-detail', compact(
-            'user',
-            'loginUser',
-            'data'
-        ));
+        return view('admin.admin-detail', [
+            'user' => $user,
+            'loginUser' => $loginUser,
+            'attendanceRecord' => $data,
+        ]);
     }
 
     /**

--- a/resources/views/admin/admin-detail.blade.php
+++ b/resources/views/admin/admin-detail.blade.php
@@ -9,7 +9,7 @@
         <div class="detail__header">
             <h1 class="content__header--item">勤怠詳細</h1>
         </div>
-        <form class="form" action="{{ url('/attendance/' . $attendanceRecord['id']) }}" method="post">
+        <form class="form" action="{{ url('/admin/attendance/detail/' . $attendanceRecord['id']) }}" method="post">
             @csrf
                 <div class="form__content">
                     <div class="form__group">


### PR DESCRIPTION
## 概要

管理者がスタッフの勤怠詳細を確認・修正できる、管理者勤怠詳細画面の表示を修正しました。

## 実装内容

* 管理者勤怠一覧から勤怠詳細画面へ遷移した際の表示先を修正
* 管理者勤怠詳細画面で `admin-detail.blade.php` が表示されるよう修正
* 管理者勤怠詳細画面に勤怠対象ユーザーの名前を表示
* 勤務日・出勤時刻・退勤時刻を表示
* 休憩時間を表示
* 備考を表示
* 管理者勤怠詳細画面の修正フォームから勤怠情報を更新できるようフォームの送信先を修正
* 管理者勤怠詳細画面の既存の更新処理を利用

## 動作確認

* [ ] 管理者が勤怠一覧から勤怠詳細画面へ遷移できる
* [ ] 管理者勤怠詳細画面で `admin-detail.blade.php` が表示される
* [ ] 勤怠対象ユーザーの名前が正しく表示される
* [ ] 勤務日が正しく表示される
* [ ] 出勤時刻・退勤時刻が正しく表示される
* [ ] 休憩時間が正しく表示される
* [ ] 備考が正しく表示される
* [ ] 修正ボタンから勤怠情報を更新できる
* [ ] 一般ユーザーの勤怠詳細画面が従来どおり表示される
* [ ] 管理者以外は管理者勤怠詳細画面を利用できない
* [ ] 関連するFeatureテストが通る

## 対応Issue

close #53
