### PR TITLE
fix: 勤怠修正申請で1桁の時刻入力を許可 #55

### DIFF
--- a/app/Http/Requests/AttendanceCorrectionRequest.php
+++ b/app/Http/Requests/AttendanceCorrectionRequest.php
@@ -6,17 +6,55 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class AttendanceCorrectionRequest extends FormRequest
 {
-    /**
-     * リクエストの認可を行う。
-     */
     public function authorize(): bool
     {
         return true;
     }
 
-    /**
-     * バリデーションルールを定義する。
+     /**
+     * バリデーション前に時刻を正規化する
      */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'new_clock_in' => $this->normalizeTime(
+                $this->input('new_clock_in')
+            ),
+            'new_clock_out' => $this->normalizeTime(
+                $this->input('new_clock_out')
+            ),
+            'new_break_in' => $this->normalizeTimes(
+                $this->input('new_break_in', [])
+            ),
+            'new_break_out' => $this->normalizeTimes(
+                $this->input('new_break_out', [])
+            ),
+        ]);
+    }
+
+    private function normalizeTime(?string $time): ?string
+    {
+        if (! $time) {
+            return $time;
+        }
+
+        if (! preg_match('/^\d{1,2}:\d{1,2}$/', $time)) {
+            return $time;
+        }
+
+        [$hour, $minute] = explode(':', $time);
+
+        return sprintf('%02d:%02d', $hour, $minute);
+    }
+
+    private function normalizeTimes(array $times): array
+    {
+        return array_map(
+            fn ($time) => $this->normalizeTime($time),
+            $times
+        );
+    }
+
     public function rules(): array
     {
         return [
@@ -58,9 +96,6 @@ class AttendanceCorrectionRequest extends FormRequest
         ];
     }
 
-    /**
-     * バリデーション後の追加チェックを行う。
-     */
     public function withValidator($validator): void
     {
         $validator->after(function ($validator) {


### PR DESCRIPTION
## 概要

勤怠修正申請において、`09:00` のような2桁形式だけでなく、`9:00` や `9:9` などの1桁を含む時刻も入力できるように修正しました。

## 実装内容

- バリデーション前に入力された時刻を `HH:MM` 形式へ正規化
- 出勤時間・退勤時間の1桁入力に対応
- 休憩開始・終了時間の1桁入力に対応
- 正規化後も既存の `date_format:H:i` による時刻バリデーションを実施
- `24:00` や `12:60` などの不正な時刻は引き続き入力不可
- DBには `HH:MM` 形式で保存されるよう対応

## 動作確認

- [ ] `9:00` で勤怠修正申請できる
- [ ] `09:00` で勤怠修正申請できる
- [ ] `9:9` で勤怠修正申請できる
- [ ] `09:9` で勤怠修正申請できる
- [ ] `9:09` で勤怠修正申請できる
- [ ] `09:09` で勤怠修正申請できる
- [ ] 不正な時刻が入力できない
- [ ] 既存の勤怠修正申請機能に影響がない
- [ ] `sail test` が成功する

## 対応Issue

close #55