### PR TITLE
fix: 一般ユーザー専用画面のアクセス制御を実装 #57

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -15,6 +15,8 @@ class LoginController extends Controller
     {
         $credentials = $request->validated();
 
+        $credentials['admin_status'] = false;
+
         if (! Auth::attempt($credentials)) {
             return back()
                 ->withErrors([

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\AdminMiddleware;
 use App\Http\Middleware\AttendanceCorrectionRequestRoleMiddleware;
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\GeneralUserMiddleware;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use App\Http\Middleware\RedirectIfAuthenticated;
 use App\Http\Middleware\TrimStrings;
@@ -90,6 +91,7 @@ class Kernel extends HttpKernel
         'throttle' => ThrottleRequests::class,
         'verified' => EnsureEmailIsVerified::class,
         'admin' => AdminMiddleware::class,
+        'general.user' => GeneralUserMiddleware::class,
         'correction.request.role' => AttendanceCorrectionRequestRoleMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/GeneralUserMiddleware.php
+++ b/app/Http/Middleware/GeneralUserMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class GeneralUserMiddleware
+{
+    /**
+     * 一般ユーザーのみアクセスを許可する。
+     */
+    public function handle(
+        Request $request,
+        Closure $next
+    ): Response {
+        if (! $request->user() || $request->user()->admin_status) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/AttendanceCorrectionRequest.php
+++ b/app/Http/Requests/AttendanceCorrectionRequest.php
@@ -11,7 +11,7 @@ class AttendanceCorrectionRequest extends FormRequest
         return true;
     }
 
-     /**
+    /**
      * バリデーション前に時刻を正規化する
      */
     protected function prepareForValidation(): void

--- a/app/Services/AdminAttendanceCorrectionRequestService.php
+++ b/app/Services/AdminAttendanceCorrectionRequestService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\AttendanceBreak;
 use App\Models\AttendanceCorrectionRequest;
+use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
 class AdminAttendanceCorrectionRequestService
@@ -49,11 +50,25 @@ class AdminAttendanceCorrectionRequestService
      */
     public function getApplication(int $id): AttendanceCorrectionRequest
     {
-        return AttendanceCorrectionRequest::with([
+        $application = AttendanceCorrectionRequest::with([
             'user',
             'attendanceRecord',
             'proposalBreaks',
         ])->findOrFail($id);
+
+        if ($application->new_clock_in) {
+            $application->new_clock_in = Carbon::parse(
+                $application->new_clock_in
+            )->format('H:i');
+        }
+
+        if ($application->new_clock_out) {
+            $application->new_clock_out = Carbon::parse(
+                $application->new_clock_out
+            )->format('H:i');
+        }
+
+        return $application;
     }
 
     /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,7 +36,7 @@ Route::post('/login', [LoginController::class, 'store'])
     ->name('login.store');
 
 // 一般ユーザー
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth', 'general.user'])->group(function () {
 
     // 勤怠登録画面
     Route::get('/attendance', [AttendanceController::class, 'create'])
@@ -60,19 +60,21 @@ Route::middleware('auth')->group(function () {
         [AttendanceCorrectionRequestController::class, 'store']
     )->name('attendance.correction.store');
 
-    // 勤怠修正申請一覧画面
+    // 勤怠修正申請詳細画面
+    Route::get(
+        '/application/detail/{id}',
+        [AttendanceCorrectionRequestController::class, 'show']
+    )->name('attendance.correction.show');
+});
+
+// 勤怠修正申請一覧画面（一般ユーザー用、管理者用）
+Route::middleware('auth')->group(function () {
     Route::get(
         '/stamp_correction_request/list',
         [AttendanceCorrectionRequestListController::class, 'index']
     )
         ->middleware('correction.request.role')
         ->name('attendance.correction.index');
-
-    // 勤怠修正申請詳細画面
-    Route::get(
-        '/application/detail/{id}',
-        [AttendanceCorrectionRequestController::class, 'show']
-    )->name('attendance.correction.show');
 });
 
 // 管理者ログイン画面

--- a/tests/Feature/AdminAttendanceCorrectionRequestTest.php
+++ b/tests/Feature/AdminAttendanceCorrectionRequestTest.php
@@ -30,8 +30,8 @@ class AdminAttendanceCorrectionRequestTest extends TestCase
         $attendanceRecord = AttendanceRecord::factory()->create([
             'user_id' => $user->id,
             'date' => '2026-09-01',
-            'clock_in' => '09:00:00',
-            'clock_out' => '18:00:00',
+            'clock_in' => '09:00',
+            'clock_out' => '18:00',
         ]);
 
         $application = $this->createCorrectionRequest(
@@ -39,10 +39,10 @@ class AdminAttendanceCorrectionRequestTest extends TestCase
             $attendanceRecord,
             AttendanceCorrectionRequest::STATUS_PENDING,
             [
-                'comment' => '勤務時間を修正してください',
+                'comment' => '勤務時間を修正',
                 'new_date' => '2026-09-01',
-                'new_clock_in' => '09:30:00',
-                'new_clock_out' => '18:30:00',
+                'new_clock_in' => '09:30',
+                'new_clock_out' => '18:30',
             ]
         );
 
@@ -62,9 +62,9 @@ class AdminAttendanceCorrectionRequestTest extends TestCase
         });
 
         $response->assertSee('申請者ユーザー');
-        $response->assertSee('勤務時間を修正してください');
-        $response->assertSee('09:30:00');
-        $response->assertSee('18:30:00');
+        $response->assertSee('勤務時間を修正');
+        $response->assertSee('09:30');
+        $response->assertSee('18:30');
     }
 
     /**
@@ -79,15 +79,15 @@ class AdminAttendanceCorrectionRequestTest extends TestCase
         $attendanceRecord = AttendanceRecord::factory()->create([
             'user_id' => $user->id,
             'date' => '2026-09-01',
-            'clock_in' => '09:00:00',
-            'clock_out' => '18:00:00',
+            'clock_in' => '09:00',
+            'clock_out' => '18:00',
             'comment' => '修正前コメント',
         ]);
 
         AttendanceBreak::factory()->create([
             'attendance_record_id' => $attendanceRecord->id,
-            'break_in' => '12:00:00',
-            'break_out' => '13:00:00',
+            'break_in' => '12:00',
+            'break_out' => '13:00',
         ]);
 
         $application = $this->createCorrectionRequest(
@@ -97,15 +97,15 @@ class AdminAttendanceCorrectionRequestTest extends TestCase
             [
                 'comment' => '修正後コメント',
                 'new_date' => '2026-09-02',
-                'new_clock_in' => '09:30:00',
-                'new_clock_out' => '18:30:00',
+                'new_clock_in' => '09:30',
+                'new_clock_out' => '18:30',
             ]
         );
 
         ProposalBreak::factory()->create([
             'attendance_correction_request_id' => $application->id,
-            'break_in' => '12:30:00',
-            'break_out' => '13:30:00',
+            'break_in' => '12:30',
+            'break_out' => '13:30',
         ]);
 
         $response = $this->post(
@@ -127,21 +127,21 @@ class AdminAttendanceCorrectionRequestTest extends TestCase
         $this->assertDatabaseHas('attendance_records', [
             'id' => $attendanceRecord->id,
             'date' => '2026-09-02 00:00:00',
-            'clock_in' => '09:30:00',
-            'clock_out' => '18:30:00',
+            'clock_in' => '09:30',
+            'clock_out' => '18:30',
             'comment' => '修正後コメント',
         ]);
 
         $this->assertDatabaseHas('breaks', [
             'attendance_record_id' => $attendanceRecord->id,
-            'break_in' => '12:30:00',
-            'break_out' => '13:30:00',
+            'break_in' => '12:30',
+            'break_out' => '13:30',
         ]);
 
         $this->assertDatabaseMissing('breaks', [
             'attendance_record_id' => $attendanceRecord->id,
-            'break_in' => '12:00:00',
-            'break_out' => '13:00:00',
+            'break_in' => '12:00',
+            'break_out' => '13:00',
         ]);
     }
 }


### PR DESCRIPTION
## 概要

一般ユーザー専用画面へのアクセス制御を実装しました。

## 実装内容

- `GeneralUserMiddleware` を作成
- `general.user` Middlewareを登録
- 一般ユーザー専用ルートに `general.user` Middlewareを適用

## 動作確認

- [ ] 一般ユーザーが一般ユーザー専用画面にアクセスできる
- [ ] 管理者が一般ユーザー専用画面へアクセスすると403になる
- [ ] 一般ユーザーが `/stamp_correction_request/list` にアクセスできる
- [ ] 管理者が `/stamp_correction_request/list` にアクセスできる
- [ ] 管理者に管理者用申請一覧が表示される
- [ ] 一般ユーザーに一般ユーザー用申請一覧が表示される
- [ ] 未ログインユーザーが認証が必要な画面へアクセスできない
- [ ] 既存の勤怠・申請機能に影響がない
- [ ] `sail test` が成功する

## 対応Issue

close #57 
