### PR TITLE
refactor: 勤怠関連Controllerのリファクタリング #59

### DIFF
--- a/app/Http/Controllers/AdminAttendanceController.php
+++ b/app/Http/Controllers/AdminAttendanceController.php
@@ -3,9 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\AttendanceCorrectionRequest as AttendanceCorrectionRequestForm;
-use App\Models\AttendanceCorrectionRequest;
-use App\Models\AttendanceRecord;
 use App\Models\User;
+use App\Services\AdminAttendanceDetailService;
 use App\Services\AdminAttendanceService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -14,7 +13,8 @@ use Illuminate\Support\Facades\Auth;
 class AdminAttendanceController extends Controller
 {
     public function __construct(
-        private AdminAttendanceService $adminAttendanceService
+        private AdminAttendanceService $adminAttendanceService,
+        private AdminAttendanceDetailService $adminAttendanceDetailService
     ) {}
 
     /**
@@ -58,54 +58,14 @@ class AdminAttendanceController extends Controller
     {
         $loginUser = Auth::user();
 
-        $attendanceRecord = AttendanceRecord::with([
-            'breaks',
-            'correctionRequests',
-            'user',
-        ])->findOrFail($id);
+        $attendanceRecord = $this->adminAttendanceDetailService
+            ->getAttendanceDetail($id);
 
-        // 勤怠対象ユーザー
-        $user = $attendanceRecord->user;
-
-        $data = [
-            'id' => $attendanceRecord->id,
-
-            'application' => $attendanceRecord->correctionRequests
-                ->where(
-                    'approval_status',
-                    AttendanceCorrectionRequest::STATUS_PENDING
-                )
-                ->first(),
-
-            'year' => Carbon::parse($attendanceRecord->date)->format('Y'),
-
-            'date' => Carbon::parse($attendanceRecord->date)->format('m/d'),
-
-            'clock_in' => $attendanceRecord->clock_in
-                ? Carbon::parse($attendanceRecord->clock_in)->format('H:i')
-                : '',
-
-            'clock_out' => $attendanceRecord->clock_out
-                ? Carbon::parse($attendanceRecord->clock_out)->format('H:i')
-                : '',
-
-            'breaks' => $attendanceRecord->breaks->map(function ($break) {
-                return [
-                    'break_in' => $break->break_in
-                        ? Carbon::parse($break->break_in)->format('H:i')
-                        : '',
-
-                    'break_out' => $break->break_out
-                        ? Carbon::parse($break->break_out)->format('H:i')
-                        : '',
-                ];
-            })->values()->all(),
-
-            'comment' => $attendanceRecord->comment ?? '',
-        ];
+        $data = $this->adminAttendanceDetailService
+            ->formatAttendanceDetail($attendanceRecord);
 
         return view('admin.admin-detail', [
-            'user' => $user,
+            'user' => $attendanceRecord->user,
             'loginUser' => $loginUser,
             'attendanceRecord' => $data,
         ]);
@@ -118,24 +78,10 @@ class AdminAttendanceController extends Controller
         AttendanceCorrectionRequestForm $request,
         int $id
     ) {
-        $attendanceRecord = AttendanceRecord::with('breaks')
-            ->findOrFail($id);
-
-        $attendanceRecord->update([
-            'clock_in' => $request->validated('new_clock_in'),
-            'clock_out' => $request->validated('new_clock_out'),
-            'comment' => $request->validated('comment'),
-        ]);
-
-        $breakIns = $request->validated('new_break_in', []);
-        $breakOuts = $request->validated('new_break_out', []);
-
-        foreach ($attendanceRecord->breaks as $index => $break) {
-            $break->update([
-                'break_in' => $breakIns[$index] ?? null,
-                'break_out' => $breakOuts[$index] ?? null,
-            ]);
-        }
+        $this->adminAttendanceDetailService->updateAttendance(
+            $id,
+            $request->validated()
+        );
 
         return redirect()
             ->route('admin.attendance.detail', $id)

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\AttendanceStoreRequest;
 use App\Services\AttendanceDetailService;
 use App\Services\AttendanceListService;
 use App\Services\AttendanceService;
@@ -43,12 +44,8 @@ class AttendanceController extends Controller
     /**
      * 勤怠打刻を処理する。
      */
-    public function store(Request $request)
+    public function store(AttendanceStoreRequest $request)
     {
-        $request->validate([
-            'action' => ['required', 'in:clock_in,clock_out,break_in,break_out'],
-        ]);
-
         $error = $this->attendanceService->process(
             Auth::user(),
             $request->input('action')
@@ -68,7 +65,6 @@ class AttendanceController extends Controller
      */
     public function index(Request $request)
     {
-        $loginUser = Auth::user();
         $user = Auth::user();
 
         $date = $request->filled('date')

--- a/app/Http/Controllers/AttendanceCorrectionRequestController.php
+++ b/app/Http/Controllers/AttendanceCorrectionRequestController.php
@@ -3,13 +3,16 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\AttendanceCorrectionRequest as AttendanceCorrectionRequestForm;
-use App\Models\AttendanceCorrectionRequest;
-use App\Models\AttendanceRecord;
+use App\Services\AttendanceCorrectionRequestService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 
 class AttendanceCorrectionRequestController extends Controller
 {
+    public function __construct(
+        private AttendanceCorrectionRequestService $attendanceCorrectionRequestService
+    ) {}
+
     /**
      * 勤怠修正申請一覧を表示する。
      */
@@ -17,24 +20,8 @@ class AttendanceCorrectionRequestController extends Controller
     {
         $user = Auth::user();
 
-        $applications = AttendanceCorrectionRequest::with(['attendanceRecord'])
-            ->where('user_id', $user->id)
-            ->get();
-
-        $formattedApplications = $applications->map(function (
-            AttendanceCorrectionRequest $application
-        ) {
-            return [
-                'id' => $application->id,
-                'attendance_record_id' => $application->attendance_record_id,
-                'approval_status' => $application->approval_status === AttendanceCorrectionRequest::STATUS_PENDING
-                    ? '承認待ち'
-                    : '承認済み',
-                'date' => $application->attendanceRecord->date,
-                'comment' => $application->comment,
-                'application_date' => $application->created_at->format('Y-m-d H:i:s'),
-            ];
-        });
+        $formattedApplications = $this->attendanceCorrectionRequestService
+            ->getApplications($user);
 
         return view('user.user-application-list', compact(
             'user',
@@ -49,9 +36,8 @@ class AttendanceCorrectionRequestController extends Controller
     {
         $user = Auth::user();
 
-        $application = AttendanceCorrectionRequest::where('id', $id)
-            ->where('user_id', $user->id)
-            ->firstOrFail();
+        $application = $this->attendanceCorrectionRequestService
+            ->getApplication($user, $id);
 
         return redirect()->route('attendance.detail', [
             'id' => $application->attendance_record_id,
@@ -67,22 +53,14 @@ class AttendanceCorrectionRequestController extends Controller
     ): RedirectResponse {
         $user = Auth::user();
 
-        $attendanceRecord = AttendanceRecord::where('id', $id)
-            ->where('user_id', $user->id)
-            ->firstOrFail();
-
-        AttendanceCorrectionRequest::create([
-            'user_id' => $user->id,
-            'attendance_record_id' => $attendanceRecord->id,
-            'approval_status' => AttendanceCorrectionRequest::STATUS_PENDING,
-            'comment' => $request->input('comment'),
-            'new_date' => $attendanceRecord->date,
-            'new_clock_in' => $request->input('new_clock_in'),
-            'new_clock_out' => $request->input('new_clock_out'),
-        ]);
+        $this->attendanceCorrectionRequestService->create(
+            $user,
+            $id,
+            $request->validated()
+        );
 
         return redirect()->route('attendance.detail', [
-            'id' => $attendanceRecord->id,
+            'id' => $id,
         ]);
     }
 }

--- a/app/Http/Requests/AttendanceStoreRequest.php
+++ b/app/Http/Requests/AttendanceStoreRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class AttendanceStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'action' => [
+                'required',
+                'in:clock_in,clock_out,break_in,break_out',
+            ],
+        ];
+    }
+}

--- a/app/Services/AdminAttendanceDetailService.php
+++ b/app/Services/AdminAttendanceDetailService.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceBreak;
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
+use Carbon\Carbon;
+
+class AdminAttendanceDetailService
+{
+    /**
+     * 指定された勤怠の詳細を取得する。
+     */
+    public function getAttendanceDetail(int $id): AttendanceRecord
+    {
+        return AttendanceRecord::with([
+            'breaks',
+            'correctionRequests',
+            'user',
+        ])->findOrFail($id);
+    }
+
+    /**
+     * 勤怠詳細画面で使用する形式に整形する。
+     */
+    public function formatAttendanceDetail(
+        AttendanceRecord $attendanceRecord
+    ): array {
+        return [
+            'id' => $attendanceRecord->id,
+
+            'application' => $attendanceRecord->correctionRequests
+                ->where(
+                    'approval_status',
+                    AttendanceCorrectionRequest::STATUS_PENDING
+                )
+                ->first(),
+
+            'year' => Carbon::parse(
+                $attendanceRecord->date
+            )->format('Y'),
+
+            'date' => Carbon::parse(
+                $attendanceRecord->date
+            )->format('m/d'),
+
+            'clock_in' => $attendanceRecord->clock_in
+                ? Carbon::parse(
+                    $attendanceRecord->clock_in
+                )->format('H:i')
+                : '',
+
+            'clock_out' => $attendanceRecord->clock_out
+                ? Carbon::parse(
+                    $attendanceRecord->clock_out
+                )->format('H:i')
+                : '',
+
+            'breaks' => $attendanceRecord->breaks
+                ->map(function (AttendanceBreak $break) {
+                    return [
+                        'break_in' => $break->break_in
+                            ? Carbon::parse(
+                                $break->break_in
+                            )->format('H:i')
+                            : '',
+
+                        'break_out' => $break->break_out
+                            ? Carbon::parse(
+                                $break->break_out
+                            )->format('H:i')
+                            : '',
+                    ];
+                })
+                ->values()
+                ->all(),
+
+            'comment' => $attendanceRecord->comment ?? '',
+        ];
+    }
+
+    /**
+     * 勤怠情報を更新する。
+     */
+    public function updateAttendance(
+        int $id,
+        array $data
+    ): void {
+        $attendanceRecord = AttendanceRecord::with('breaks')
+            ->findOrFail($id);
+
+        $attendanceRecord->update([
+            'clock_in' => $data['new_clock_in'],
+            'clock_out' => $data['new_clock_out'],
+            'comment' => $data['comment'],
+        ]);
+
+        $breakIns = $data['new_break_in'] ?? [];
+        $breakOuts = $data['new_break_out'] ?? [];
+
+        foreach ($attendanceRecord->breaks as $index => $break) {
+            $break->update([
+                'break_in' => $breakIns[$index] ?? null,
+                'break_out' => $breakOuts[$index] ?? null,
+            ]);
+        }
+    }
+}

--- a/app/Services/AttendanceCorrectionRequestService.php
+++ b/app/Services/AttendanceCorrectionRequestService.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceCorrectionRequest;
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+class AttendanceCorrectionRequestService
+{
+    /**
+     * 一般ユーザー自身の勤怠修正申請を取得する。
+     */
+    public function getApplications(User $user): Collection
+    {
+        return AttendanceCorrectionRequest::with([
+            'attendanceRecord',
+        ])
+            ->where('user_id', $user->id)
+            ->get()
+            ->map(function (
+                AttendanceCorrectionRequest $application
+            ) {
+                return [
+                    'id' => $application->id,
+                    'attendance_record_id' => $application->attendance_record_id,
+                    'approval_status' => $application->approval_status ===
+                        AttendanceCorrectionRequest::STATUS_PENDING
+                            ? '承認待ち'
+                            : '承認済み',
+                    'date' => $application->attendanceRecord->date,
+                    'comment' => $application->comment,
+                    'application_date' => $application->created_at->format(
+                        'Y-m-d H:i:s'
+                    ),
+                ];
+            });
+    }
+
+    /**
+     * 一般ユーザー自身の勤怠修正申請を取得する。
+     */
+    public function getApplication(
+        User $user,
+        int $id
+    ): AttendanceCorrectionRequest {
+        return AttendanceCorrectionRequest::where('id', $id)
+            ->where('user_id', $user->id)
+            ->firstOrFail();
+    }
+
+    /**
+     * 一般ユーザーの勤怠修正申請を登録する。
+     */
+    public function create(
+        User $user,
+        int $attendanceRecordId,
+        array $data
+    ): AttendanceCorrectionRequest {
+        $attendanceRecord = AttendanceRecord::where('id', $attendanceRecordId)
+            ->where('user_id', $user->id)
+            ->firstOrFail();
+
+        return AttendanceCorrectionRequest::create([
+            'user_id' => $user->id,
+            'attendance_record_id' => $attendanceRecord->id,
+            'approval_status' => AttendanceCorrectionRequest::STATUS_PENDING,
+            'comment' => $data['comment'],
+            'new_date' => $attendanceRecord->date,
+            'new_clock_in' => $data['new_clock_in'],
+            'new_clock_out' => $data['new_clock_out'],
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要

勤怠関連Controllerの責務を整理し、ServiceやFormRequestへ処理を分離するリファクタリングを実施しました。

## 実装内容

- `AdminAttendanceDetailService` を作成
- 管理者勤怠詳細に関する処理をServiceへ移行
- `AttendanceCorrectionRequestService` を作成
- 勤怠修正申請に関する処理をServiceへ移行
- `AttendanceStoreRequest` を作成
- 勤怠打刻処理のバリデーションをFormRequestへ分離
- `AdminAttendanceController` の処理を整理
- `AttendanceController` の処理を整理
- `AttendanceCorrectionRequestController` の処理を整理
- 不要な `use` や重複処理を削除

## 動作確認

- [ ] 一般ユーザーの勤怠打刻が正常に動作する
- [ ] 一般ユーザーの勤怠一覧が正常に表示される
- [ ] 一般ユーザーの勤怠詳細が正常に表示される
- [ ] 一般ユーザーの勤怠修正申請が正常に動作する
- [ ] 一般ユーザーの申請一覧が正常に表示される
- [ ] 管理者の勤怠一覧が正常に表示される
- [ ] 管理者の勤怠詳細が正常に表示される
- [ ] 管理者による勤怠修正が正常に動作する
- [ ] 既存の勤怠・申請機能に影響がない
- [ ] `sail test` が成功する

## 対応Issue

close #59