### PR TITLE
feat: メール認証・認証メール再送機能 #64

### DIFF
--- a/app/Http/Controllers/RegisterController.php
+++ b/app/Http/Controllers/RegisterController.php
@@ -24,6 +24,8 @@ class RegisterController extends Controller
 
         Auth::login($user);
 
-        return redirect()->route('attendance.create');
+        $user->sendEmailVerificationNotification();
+
+        return redirect()->route('verification.notice');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,14 +2,14 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens, HasFactory, Notifiable;
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -68,8 +68,14 @@ class FortifyServiceProvider extends ServiceProvider
             return view('user.user-login');
         });
 
+        // 一般ユーザーの登録画面を表示する
         Fortify::registerView(function () {
             return view('user.register');
+        });
+
+        // 一般ユーザーのメール確認画面を表示する
+        Fortify::verifyEmailView(function () {
+            return view('auth.verify-email');
         });
     }
 }

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -147,7 +147,7 @@ return [
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
-        // Features::emailVerification(),
+        Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication([

--- a/lang/ja/verification.php
+++ b/lang/ja/verification.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'verification-link-sent' => '認証メールを再送しました。',
+];

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -21,8 +21,10 @@
     </header>
     <main>
         <div class="verify__content">
-            @if (session('message'))
-                <div class="verify__flash">{{ session('message') }}</div>
+            @if (session('status'))
+                <div class="verify__flash">
+                    {{ __('verification.' . session('status')) }}
+                </div>
             @endif
 
             <p class="verify__text">

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,7 +36,7 @@ Route::post('/login', [LoginController::class, 'store'])
     ->name('login.store');
 
 // 一般ユーザー
-Route::middleware(['auth', 'general.user'])->group(function () {
+Route::middleware(['auth', 'verified', 'general.user'])->group(function () {
 
     // 勤怠登録画面
     Route::get('/attendance', [AttendanceController::class, 'create'])
@@ -68,7 +68,7 @@ Route::middleware(['auth', 'general.user'])->group(function () {
 });
 
 // 勤怠修正申請一覧画面（一般ユーザー用、管理者用）
-Route::middleware('auth')->group(function () {
+Route::middleware('auth', 'verified')->group(function () {
     Route::get(
         '/stamp_correction_request/list',
         [AttendanceCorrectionRequestListController::class, 'index']

--- a/tests/Feature/Auth/RegisterTest.php
+++ b/tests/Feature/Auth/RegisterTest.php
@@ -123,7 +123,7 @@ class RegisterTest extends TestCase
             'password_confirmation' => 'password',
         ]);
 
-        $response->assertRedirect(route('attendance.create'));
+        $response->assertRedirect(route('verification.notice'));
 
         $this->assertDatabaseHas('users', [
             'name' => 'テストユーザー',


### PR DESCRIPTION
# 概要

一般ユーザーの新規会員登録時および初回ログイン時に、メール認証を行える機能を実装しました。

また、メール認証誘導画面から認証メールを再送信できる機能を実装し、Mailpitを利用して認証メールの送受信を確認できるようにしました。

## 変更内容

- 新規会員登録時のメール認証機能を実装
- メール認証誘導画面を表示
- メール認証画面への遷移処理を実装
- 認証メールの送信処理を実装
- 認証メールに記載されたリンクからメール認証を完了する処理を実装
- メール認証完了後に勤怠登録画面へ遷移する処理を実装
- 未認証ユーザーが勤怠画面へアクセスした際のメール認証誘導を実装
- Mailpitを利用した認証メールの確認
- メール認証誘導画面に「認証メールを再送する」ボタンを追加
- 認証メールの再送処理を実装
- 再送後のメール送信結果を画面に表示
- 未認証ユーザーのみ認証メールを再送できるように制御
- 認証済みユーザーが不要に認証メールを再送できないように制御
- メール認証に関するテストを修正・追加

## 動作確認

- [ ] 新規会員登録時に認証メールが送信される
- [ ] 会員登録後にメール認証誘導画面が表示される
- [ ] メール認証誘導画面から認証メールを確認できる
- [ ] 未認証ユーザーがログインするとメール認証誘導画面へ遷移する
- [ ] 認証メールに記載されたリンクからメール認証を完了できる
- [ ] メール認証完了後に勤怠登録画面へ遷移できる
- [ ] Mailpitで認証メールを確認できる
- [ ] 未認証ユーザーが認証済みユーザーとして扱われない
- [ ] メール認証誘導画面に「認証メールを再送する」ボタンが表示される
- [ ] 「認証メールを再送する」ボタンを押下すると認証メールを再送信できる
- [ ] 再送信された認証メールをMailpitで確認できる
- [ ] 再送後に「認証メールを再送しました。」と表示される
- [ ] 未認証ユーザーのみ認証メールを再送できる
- [ ] 認証済みユーザーが不要に認証メールを再送できない
- [ ] メール認証済みユーザーは通常どおり勤怠登録画面へ遷移できる

## 対応issue

close #64
