### PR TITLE
feat: 管理者勤怠一覧CSV出力機能 #66

### DIFF
--- a/app/Http/Controllers/AdminAttendanceController.php
+++ b/app/Http/Controllers/AdminAttendanceController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\AdminAttendanceCsvRequest;
 use App\Http\Requests\AttendanceCorrectionRequest as AttendanceCorrectionRequestForm;
 use App\Models\User;
+use App\Services\AdminAttendanceCsvService;
 use App\Services\AdminAttendanceDetailService;
 use App\Services\AdminAttendanceService;
 use Carbon\Carbon;
@@ -11,12 +13,14 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class AdminAttendanceController extends Controller
 {
     public function __construct(
         private AdminAttendanceService $adminAttendanceService,
-        private AdminAttendanceDetailService $adminAttendanceDetailService
+        private AdminAttendanceDetailService $adminAttendanceDetailService,
+        private AdminAttendanceCsvService $adminAttendanceCsvService
     ) {}
 
     /**
@@ -136,5 +140,41 @@ class AdminAttendanceController extends Controller
             'nextMonth',
             'formattedAttendanceRecords'
         ));
+    }
+
+    /**
+     * スタッフ別月次勤怠一覧をCSV出力する。
+     *
+     * @param  AdminAttendanceCsvRequest  $request  CSV出力リクエスト
+     * @return StreamedResponse CSVファイルのダウンロード
+     */
+    public function export(
+        AdminAttendanceCsvRequest $request
+    ): StreamedResponse {
+        $user = User::findOrFail($request->input('user_id'));
+
+        $date = Carbon::createFromFormat(
+            'Y-m',
+            $request->input('year_month')
+        );
+
+        $attendanceRecords = $this->adminAttendanceService
+            ->getStaffMonthlyRecords($user, $date);
+
+        $csv = $this->adminAttendanceCsvService
+            ->generate($attendanceRecords);
+
+        $fileName = $this->adminAttendanceCsvService
+            ->generateFileName($user->name, $date);
+
+        return response()->streamDownload(
+            function () use ($csv): void {
+                echo $csv;
+            },
+            $fileName,
+            [
+                'Content-Type' => 'text/csv; charset=UTF-8',
+            ]
+        );
     }
 }

--- a/app/Http/Requests/AdminAttendanceCsvRequest.php
+++ b/app/Http/Requests/AdminAttendanceCsvRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AdminAttendanceCsvRequest extends FormRequest
+{
+    /**
+     * リクエストの認可を判定する。
+     *
+     * @return bool 認可結果
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * バリデーションルールを取得する。
+     *
+     * @return array<string, string> バリデーションルール
+     */
+    public function rules(): array
+    {
+        return [
+            'user_id' => ['required', 'integer', 'exists:users,id'],
+            'year_month' => [
+                'required',
+                'date_format:Y-m',
+            ],
+        ];
+    }
+}

--- a/app/Services/AdminAttendanceCsvService.php
+++ b/app/Services/AdminAttendanceCsvService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class AdminAttendanceCsvService
+{
+    /**
+     * CSVファイルを生成する。
+     *
+     * @param  Collection<int, array<string, mixed>>  $attendanceRecords
+     * @return string CSVデータ
+     */
+    public function generate(
+        Collection $attendanceRecords
+    ): string {
+        $handle = fopen('php://memory', 'w+');
+
+        fwrite($handle, "\xEF\xBB\xBF");
+
+        fputcsv($handle, [
+            '日付',
+            '出勤',
+            '退勤',
+            '休憩',
+            '合計',
+        ]);
+
+        $attendanceRecords->each(
+            function (array $attendanceRecord) use ($handle): void {
+                fputcsv($handle, [
+                    $attendanceRecord['date'],
+                    $attendanceRecord['clock_in'],
+                    $attendanceRecord['clock_out'],
+                    $this->formatTime(
+                        $attendanceRecord['total_break_time']
+                    ),
+                    $this->formatTime(
+                        $attendanceRecord['total_time']
+                    ),
+                ]);
+            }
+        );
+
+        rewind($handle);
+
+        $csv = stream_get_contents($handle);
+
+        fclose($handle);
+
+        return $csv;
+    }
+
+    /**
+     * 時間をCSV表示用に整形する。
+     *
+     * @param  string|null  $time  時間
+     * @return string 整形された時間
+     */
+    private function formatTime(?string $time): string
+    {
+        return $time
+            ? Carbon::parse($time)->format('G:i')
+            : '';
+    }
+
+    /**
+     * CSVファイル名を生成する。
+     *
+     * @param  string  $userName  ユーザー名
+     * @param  Carbon  $date  対象月
+     * @return string CSVファイル名
+     */
+    public function generateFileName(
+        string $userName,
+        Carbon $date
+    ): string {
+        return sprintf(
+            '%s_%s.csv',
+            $userName,
+            $date->format('Y-m')
+        );
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -122,6 +122,12 @@ Route::middleware(['auth', 'admin'])->group(function () {
         [AdminAttendanceController::class, 'staff']
     )->name('admin.attendance.staff');
 
+    // スタッフ別月次勤怠一覧のCSV出力
+    Route::post(
+        '/export',
+        [AdminAttendanceController::class, 'export']
+    )->name('admin.attendance.export');
+
     // 管理者勤怠修正申請詳細画面
     Route::get(
         '/stamp_correction_request/approve/{id}',


### PR DESCRIPTION
# 概要

管理者が選択したスタッフの月次勤怠一覧情報をCSV形式で出力・ダウンロードできる機能を実装しました。

また、選択した対象ユーザー・対象年月の勤怠情報のみをCSVに出力し、勤怠一覧画面と同じ項目構成で確認できるようにしました。

## 変更内容

- 月次勤怠情報をCSV形式に変換する処理を実装
- CSVファイルをダウンロードする処理を実装
- CSV出力用のリクエストバリデーションを実装
- CSV出力処理を専用サービスに分離
- 勤怠一覧画面とCSVの項目構成を統一
- 勤怠情報が存在しない項目を空欄で出力するように実装
- 選択した対象ユーザーの勤怠情報のみ出力するように制御
- 選択した対象年月の勤怠情報のみ出力するように制御
- CSVをExcel等で開いた際の日本語文字化けを防ぐためUTF-8 BOMを付与
- CSVファイル名に対象ユーザー名と対象年月を設定

## 動作確認

- [ ] 「CSV出力」を押下するとCSVファイルをダウンロードできる
- [ ] 選択した月の勤怠一覧情報がCSVに出力される
- [ ] 勤怠一覧画面とCSVの項目構成が一致している
- [ ] 勤怠情報が存在しない項目が空欄で出力される
- [ ] 選択した対象ユーザー以外の勤怠情報が出力されない
- [ ] 選択した対象年月以外の勤怠情報が出力されない
- [ ] CSVの日本語が文字化けせず表示される

## 対応issue

close #66
