### PR TITLE
feat: マイ勤怠レポート機能 #67

### DIFF
--- a/app/Http/Controllers/AttendanceReportController.php
+++ b/app/Http/Controllers/AttendanceReportController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\AttendanceReportAnomalyService;
+use App\Services\AttendanceReportService;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class AttendanceReportController extends Controller
+{
+    public function __construct(
+        private AttendanceReportService $attendanceReportService,
+        private AttendanceReportAnomalyService $anomalyService
+    ) {}
+
+    /**
+     * マイ勤怠レポート画面を表示する。
+     *
+     * ログインユーザーの過去6か月分と今月の勤怠情報を取得し、
+     * 基本サマリー、月次推移、異常勤怠を画面に渡す。
+     *
+     * @return View マイ勤怠レポート画面
+     */
+    public function index(): View
+    {
+        $user = Auth::user();
+
+        $attendanceRecords = $this->attendanceReportService
+            ->getAttendanceRecords($user);
+
+        $dailyResults = $this->attendanceReportService
+            ->calculateDailyResults($attendanceRecords);
+
+        $summary = $this->attendanceReportService
+            ->getSummary($dailyResults);
+
+        $monthlyTrend = $this->attendanceReportService
+            ->getMonthlySummary($dailyResults);
+
+        $anomalies = $this->anomalyService
+            ->getAnomalies($dailyResults);
+
+        return view('reports.index', compact(
+            'summary',
+            'monthlyTrend',
+            'anomalies'
+        ));
+    }
+}

--- a/app/Services/AttendanceReportAnomalyService.php
+++ b/app/Services/AttendanceReportAnomalyService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class AttendanceReportAnomalyService
+{
+    /**
+     * 今月の異常勤怠件数を取得する。
+     *
+     * 遅刻、早退、長時間労働の発生回数を集計する。
+     *
+     * @param  Collection<int, array<string, mixed>>  $dailyResults
+     *                                                               1日ごとの計算結果のCollection
+     * @return array<string, int> 異常勤怠件数
+     */
+    public function getAnomalies(
+        Collection $dailyResults
+    ): array {
+        $currentMonth = now();
+
+        $monthlyResults = $dailyResults->filter(
+            fn (array $result): bool => Carbon::parse($result['record']->date)
+                ->isSameMonth($currentMonth)
+        );
+
+        $lateCount = $monthlyResults
+            ->filter(
+                fn (array $result): bool => $result['record']->clock_in &&
+                    Carbon::parse($result['record']->clock_in)
+                        ->gt(Carbon::parse('09:00:00'))
+            )
+            ->count();
+
+        $earlyLeaveCount = $monthlyResults
+            ->filter(
+                fn (array $result): bool => $result['record']->clock_out &&
+                    Carbon::parse($result['record']->clock_out)
+                        ->lt(Carbon::parse('18:00:00'))
+            )
+            ->count();
+
+        $longWorkCount = $monthlyResults
+            ->filter(
+                fn (array $result): bool => $result['work_seconds'] !== null &&
+                    $result['work_seconds'] > (10 * 3600)
+            )
+            ->count();
+
+        return [
+            'late_count' => $lateCount,
+            'early_leave_count' => $earlyLeaveCount,
+            'long_work_count' => $longWorkCount,
+        ];
+    }
+}

--- a/app/Services/AttendanceReportCalculator.php
+++ b/app/Services/AttendanceReportCalculator.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceBreak;
+use App\Models\AttendanceRecord;
+use Carbon\Carbon;
+
+class AttendanceReportCalculator
+{
+    /**
+     * 1日の勤怠時間を計算する。
+     *
+     * 実働時間と残業時間をまとめて計算する。
+     *
+     * @param  AttendanceRecord  $attendanceRecord  勤怠記録
+     * @return array<string, int|null> 1日の勤怠計算結果
+     */
+    public function calculate(
+        AttendanceRecord $attendanceRecord
+    ): array {
+        $workSeconds = $this->calculateWorkSeconds($attendanceRecord);
+
+        if ($workSeconds === null) {
+            return [
+                'work_seconds' => null,
+                'overtime_seconds' => null,
+            ];
+        }
+
+        return [
+            'work_seconds' => $workSeconds,
+            'overtime_seconds' => max(
+                $workSeconds - (8 * 3600),
+                0
+            ),
+        ];
+    }
+
+    /**
+     * 1日の実働時間を秒数で計算する。
+     *
+     * 退勤時刻から出勤時刻を引き、
+     * 完了した休憩時間の合計を差し引いて算出する。
+     *
+     * @param  AttendanceRecord  $attendanceRecord  勤怠記録
+     * @return int|null 実働時間（秒）
+     */
+    private function calculateWorkSeconds(
+        AttendanceRecord $attendanceRecord
+    ): ?int {
+        if (
+            ! $attendanceRecord->clock_in ||
+            ! $attendanceRecord->clock_out
+        ) {
+            return null;
+        }
+
+        $clockIn = Carbon::parse($attendanceRecord->clock_in);
+        $clockOut = Carbon::parse($attendanceRecord->clock_out);
+
+        $workSeconds = $clockIn->diffInSeconds($clockOut);
+
+        $breakSeconds = $attendanceRecord->breaks
+            ->filter(function (AttendanceBreak $break): bool {
+                return $break->break_in && $break->break_out;
+            })
+            ->sum(function (AttendanceBreak $break): int {
+                $breakIn = Carbon::parse($break->break_in);
+                $breakOut = Carbon::parse($break->break_out);
+
+                return $breakIn->diffInSeconds($breakOut);
+            });
+
+        return $workSeconds - $breakSeconds;
+    }
+}

--- a/app/Services/AttendanceReportService.php
+++ b/app/Services/AttendanceReportService.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+class AttendanceReportService
+{
+    public function __construct(
+        private AttendanceReportCalculator $calculator,
+    ) {}
+
+    /**
+     * 今月と今月を除く過去6か月分の勤怠記録を取得する。
+     *
+     * @param  User  $user  対象ユーザー
+     * @return Collection<int, AttendanceRecord> 勤怠記録のCollection
+     */
+    public function getAttendanceRecords(User $user): Collection
+    {
+        $startDate = now()
+            ->startOfMonth()
+            ->subMonths(6);
+
+        $endDate = now()->endOfMonth();
+
+        return AttendanceRecord::with('breaks')
+            ->where('user_id', $user->id)
+            ->whereBetween('date', [
+                $startDate->toDateString(),
+                $endDate->toDateString(),
+            ])
+            ->get();
+    }
+
+    /**
+     * 勤怠記録から1日ごとの計算結果を作成する。
+     *
+     * @param  Collection<int, AttendanceRecord>  $attendanceRecords
+     *                                                                勤怠記録のCollection
+     * @return Collection<int, array<string, mixed>> 1日ごとの計算結果
+     */
+    public function calculateDailyResults(
+        Collection $attendanceRecords
+    ): Collection {
+        return $attendanceRecords->map(
+            function (AttendanceRecord $attendanceRecord): array {
+                return [
+                    'record' => $attendanceRecord,
+                    ...$this->calculator->calculate($attendanceRecord),
+                ];
+            }
+        );
+    }
+
+    /**
+     * 基本サマリーを取得する。
+     *
+     * 総労働時間、総残業時間、平均労働時間を計算する。
+     *
+     * @param  Collection<int, array<string, mixed>>  $dailyResults
+     *                                                               1日ごとの計算結果のCollection
+     * @return array<string, int> 基本サマリー
+     */
+    public function getSummary(
+        Collection $dailyResults
+    ): array {
+        $startDate = now()
+            ->startOfMonth()
+            ->subMonths(6);
+
+        $endDate = now()
+            ->startOfMonth()
+            ->subDay();
+
+        $targetResults = $dailyResults->filter(
+            fn (array $result): bool => Carbon::parse($result['record']->date)->between(
+                $startDate,
+                $endDate
+            )
+        );
+
+        $workSeconds = $targetResults
+            ->filter(
+                fn (array $result): bool => $result['work_seconds'] !== null
+            )
+            ->sum('work_seconds');
+
+        $overtimeSeconds = $targetResults
+            ->filter(
+                fn (array $result): bool => $result['overtime_seconds'] !== null
+            )
+            ->sum('overtime_seconds');
+
+        $workDays = $targetResults
+            ->filter(
+                fn (array $result): bool => $result['work_seconds'] !== null
+            )
+            ->count();
+
+        $averageWorkSeconds = $workDays > 0
+            ? intdiv($workSeconds, $workDays)
+            : 0;
+
+        return [
+            'total_work_minutes' => intdiv($workSeconds, 60),
+            'total_overtime_minutes' => intdiv($overtimeSeconds, 60),
+            'avg_work_minutes' => intdiv($averageWorkSeconds, 60),
+        ];
+    }
+
+    /**
+     * 過去6か月分の月次勤怠サマリーを取得する。
+     *
+     * 勤怠記録が存在しない月も0時間として返す。
+     *
+     * @param  Collection<int, array<string, mixed>>  $dailyResults
+     *                                                               日次勤怠結果のCollection
+     * @return Collection<int, array<string, int|string>> 月次勤怠サマリー
+     */
+    public function getMonthlySummary(
+        Collection $dailyResults
+    ): Collection {
+        $startMonth = now()
+            ->startOfMonth()
+            ->subMonths(6);
+
+        return collect(range(0, 5))->map(
+            function (int $month) use (
+                $startMonth,
+                $dailyResults
+            ): array {
+                $targetMonth = $startMonth->copy()->addMonths($month);
+
+                $monthlyResults = $dailyResults->filter(
+                    fn (array $result): bool => Carbon::parse($result['record']->date)
+                        ->isSameMonth($targetMonth)
+                );
+
+                $workSeconds = $monthlyResults
+                    ->filter(
+                        fn (array $result): bool => $result['work_seconds'] !== null
+                    )
+                    ->sum('work_seconds');
+
+                $overtimeSeconds = $monthlyResults
+                    ->filter(
+                        fn (array $result): bool => $result['overtime_seconds'] !== null
+                    )
+                    ->sum('overtime_seconds');
+
+                return [
+                    'month' => $targetMonth->format('Y-m'),
+                    'work_minutes' => intdiv($workSeconds, 60),
+                    'overtime_minutes' => intdiv(
+                        $overtimeSeconds,
+                        60
+                    ),
+                ];
+            }
+        );
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\AdminStaffController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\AttendanceCorrectionRequestController;
 use App\Http\Controllers\AttendanceCorrectionRequestListController;
+use App\Http\Controllers\AttendanceReportController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\RegisterController;
 use Illuminate\Support\Facades\Route;
@@ -65,6 +66,12 @@ Route::middleware(['auth', 'verified', 'general.user'])->group(function () {
         '/application/detail/{id}',
         [AttendanceCorrectionRequestController::class, 'show']
     )->name('attendance.correction.show');
+
+    // マイ勤怠レポート画面
+    Route::get(
+        '/attendance/report',
+        [AttendanceReportController::class, 'index']
+    )->name('attendance.report');
 });
 
 // 勤怠修正申請一覧画面（一般ユーザー用、管理者用）

--- a/tests/Feature/AdminAttendanceCsvTest.php
+++ b/tests/Feature/AdminAttendanceCsvTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AttendanceBreak;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\AdminAttendanceCsvTestHelper;
+use Tests\TestCase;
+
+class AdminAttendanceCsvTest extends TestCase
+{
+    use AdminAttendanceCsvTestHelper;
+    use RefreshDatabase;
+
+    /**
+     * 管理者がスタッフの月次勤怠をCSV出力できる。
+     */
+    public function test_admin_can_export_staff_monthly_attendance_as_csv(): void
+    {
+        $admin = $this->createAdmin();
+        $user = $this->createUser();
+
+        $attendanceRecord = $this->createAttendanceRecord(
+            $user,
+            '2026-09-01'
+        );
+
+        AttendanceBreak::factory()->create([
+            'attendance_record_id' => $attendanceRecord->id,
+            'break_in' => '12:00:00',
+            'break_out' => '13:00:00',
+        ]);
+
+        $response = $this->exportCsv($admin, $user);
+
+        $response->assertOk();
+
+        $response->assertHeader(
+            'Content-Type',
+            'text/csv; charset=UTF-8'
+        );
+
+        $contentDisposition = $response->headers->get(
+            'Content-Disposition'
+        );
+
+        $this->assertStringContainsString(
+            rawurlencode($user->name.'_2026-09.csv'),
+            $contentDisposition
+        );
+    }
+
+    /**
+     * CSVに対象ユーザーの勤怠情報が正しく出力される。
+     */
+    public function test_csv_contains_staff_attendance_data(): void
+    {
+        $admin = $this->createAdmin();
+        $user = $this->createUser();
+
+        $attendanceRecord = $this->createAttendanceRecord(
+            $user,
+            '2026-09-01'
+        );
+
+        AttendanceBreak::factory()->create([
+            'attendance_record_id' => $attendanceRecord->id,
+            'break_in' => '12:00:00',
+            'break_out' => '13:00:00',
+        ]);
+
+        $response = $this->exportCsv($admin, $user);
+
+        $csv = $response->streamedContent();
+
+        $this->assertStringContainsString(
+            '日付,出勤,退勤,休憩,合計',
+            $csv
+        );
+
+        $this->assertStringContainsString(
+            '09/01,09:00,18:00,1:00,8:00',
+            $csv
+        );
+    }
+
+    /**
+     * 対象ユーザー・対象年月以外の勤怠情報がCSVに出力されない。
+     */
+    public function test_csv_does_not_contain_other_users_or_months_attendance(): void
+    {
+        $admin = $this->createAdmin();
+        $user = $this->createUser();
+        $otherUser = $this->createUser();
+
+        // 対象ユーザー・対象年月 → 出力される
+        $this->createAttendanceRecord(
+            $user,
+            '2026-09-01'
+        );
+
+        // 対象ユーザー・別年月 → 出力されない
+        $this->createAttendanceRecord(
+            $user,
+            '2026-08-01',
+            '10:00:00',
+            '19:00:00'
+        );
+
+        // 別ユーザー・対象年月 → 出力されない
+        $this->createAttendanceRecord(
+            $otherUser,
+            '2026-09-01',
+            '11:00:00',
+            '20:00:00'
+        );
+
+        $response = $this->exportCsv($admin, $user);
+
+        $csv = $response->streamedContent();
+
+        // 対象ユーザー・対象年月の勤怠は出力される
+        $this->assertStringContainsString(
+            '09/01,09:00,18:00',
+            $csv
+        );
+
+        // 対象ユーザーの別年月の勤怠は出力されない
+        $this->assertStringNotContainsString(
+            '08/01,10:00,19:00',
+            $csv
+        );
+
+        // 別ユーザーの勤怠は出力されない
+        $this->assertStringNotContainsString(
+            '09/01,11:00,20:00',
+            $csv
+        );
+    }
+
+    /**
+     * 勤怠情報が存在しない項目はCSVで空欄になる。
+     */
+    public function test_csv_outputs_blank_when_attendance_information_is_missing(): void
+    {
+        $admin = $this->createAdmin();
+        $user = $this->createUser();
+
+        // 出勤・退勤がある勤怠
+        $this->createAttendanceRecord(
+            $user,
+            '2026-09-01'
+        );
+
+        // 出勤のみで退勤がない勤怠
+        $this->createAttendanceRecord(
+            $user,
+            '2026-09-02',
+            '09:00:00',
+            null
+        );
+
+        // 勤怠レコードが存在しない2026-09-03は、
+        // 月次勤怠一覧に空欄の行として出力される
+        $response = $this->exportCsv($admin, $user);
+
+        $csv = $response->streamedContent();
+
+        // 出勤・退勤がある日は正常に出力される
+        $this->assertStringContainsString(
+            '09/01,09:00,18:00,,9:00',
+            $csv
+        );
+
+        // 退勤がない場合、退勤・休憩・合計が空欄になる
+        $this->assertStringContainsString(
+            '09/02,09:00,,,',
+            $csv
+        );
+
+        // 勤怠レコードがない日は、すべて空欄になる
+        $this->assertStringContainsString(
+            '09/03,,,,',
+            $csv
+        );
+    }
+}

--- a/tests/Support/AdminAttendanceCsvTestHelper.php
+++ b/tests/Support/AdminAttendanceCsvTestHelper.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+use Illuminate\Testing\TestResponse;
+
+trait AdminAttendanceCsvTestHelper
+{
+    /**
+     * 管理者ユーザーを作成する。
+     *
+     * @return User 管理者ユーザー
+     */
+    protected function createAdmin(): User
+    {
+        return User::factory()->create([
+            'admin_status' => true,
+        ]);
+    }
+
+    /**
+     * 一般ユーザーを作成する。
+     *
+     * @return User 一般ユーザー
+     */
+    protected function createUser(): User
+    {
+        return User::factory()->create([
+            'admin_status' => false,
+        ]);
+    }
+
+    /**
+     * CSV出力リクエストを実行する。
+     *
+     * @param  User  $admin  管理者ユーザー
+     * @param  User  $user  対象スタッフ
+     * @param  string  $yearMonth  対象年月
+     * @return TestResponse CSVレスポンス
+     */
+    protected function exportCsv(
+        User $admin,
+        User $user,
+        string $yearMonth = '2026-09'
+    ): TestResponse {
+        return $this
+            ->actingAs($admin)
+            ->post(route('admin.attendance.export'), [
+                'user_id' => $user->id,
+                'year_month' => $yearMonth,
+            ]);
+    }
+
+    /**
+     * 勤怠記録を作成する。
+     *
+     * @param  User  $user  対象ユーザー
+     * @param  string  $date  勤怠日
+     * @param  string|null  $clockIn  出勤時刻
+     * @param  string|null  $clockOut  退勤時刻
+     * @return AttendanceRecord 勤怠記録
+     */
+    protected function createAttendanceRecord(
+        User $user,
+        string $date,
+        ?string $clockIn = '09:00:00',
+        ?string $clockOut = '18:00:00'
+    ): AttendanceRecord {
+        return AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => $date,
+            'clock_in' => $clockIn,
+            'clock_out' => $clockOut,
+        ]);
+    }
+}


### PR DESCRIPTION
# 概要

一般ユーザーが、自分自身の過去6ヶ月分の勤怠統計レポートを確認できる「マイ勤怠レポート機能」を実装しました。

過去6ヶ月の総労働時間・総残業時間・平均労働時間に加えて、月別の労働時間・残業時間を確認できるようにしました。

また、当月の遅刻・早退・長時間労働の回数も確認できるようにしました。

## 変更内容

- マイ勤怠レポート画面を実装
- `/attendance/report` からレポート画面へアクセスできるように実装
- 未認証ユーザーがアクセスした場合に `/login` へリダイレクトするように実装
- ログインユーザー自身の勤怠情報のみ取得・表示するように実装
- 過去6ヶ月の総労働時間を表示する処理を実装
- 過去6ヶ月の総残業時間を表示する処理を実装
- 1日あたりの平均労働時間を表示する処理を実装
- 過去6ヶ月の労働時間を月別に表示する処理を実装
- 過去6ヶ月の残業時間を月別に表示する処理を実装
- 勤怠データが存在しない月も0として表示するように実装
- 当月の遅刻回数を表示する処理を実装
- 当月の早退回数を表示する処理を実装
- 当月の長時間労働回数を表示する処理を実装
- 勤怠レポートの集計処理を専用サービスに分離

## 動作確認

- [ ] 一般ユーザーが `/attendance/report` にアクセスできる
- [ ] 未認証ユーザーが `/attendance/report` にアクセスすると `/login` へリダイレクトされる
- [ ] ログインユーザー自身の勤怠統計が表示される
- [ ] 過去6ヶ月の総労働時間が正しく表示される
- [ ] 過去6ヶ月の総残業時間が正しく表示される
- [ ] 1日あたりの平均労働時間が正しく表示される
- [ ] 過去6ヶ月の労働時間が月別に表示される
- [ ] 過去6ヶ月の残業時間が月別に表示される
- [ ] 勤怠データがない月が0として表示される
- [ ] 当月の遅刻回数が正しく表示される
- [ ] 当月の早退回数が正しく表示される
- [ ] 当月の長時間労働回数が正しく表示される

## 対応issue

close #67 
