### PR TITLE
test: マイ勤怠レポート機能テスト実装 #74

### DIFF
--- a/tests/Feature/AttendanceReportTest.php
+++ b/tests/Feature/AttendanceReportTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+use Tests\Support\AttendanceReportTestHelper;
+use Tests\TestCase;
+
+class AttendanceReportTest extends TestCase
+{
+    use AttendanceReportTestHelper;
+    use RefreshDatabase;
+
+    /**
+     * 勤怠レポートのサマリーが正しいことを検証する。
+     */
+    private function assertSummary(TestResponse $response): void
+    {
+        $response->assertViewHas('summary', [
+            'total_work_minutes' => 1020,
+            'total_overtime_minutes' => 60,
+            'avg_work_minutes' => 510,
+        ]);
+    }
+
+    /**
+     * 勤怠レポートの月別推移が正しいことを検証する。
+     */
+    private function assertMonthlyTrend(TestResponse $response): void
+    {
+        $response->assertViewHas('monthlyTrend', function ($monthlyTrend) {
+            $months = $monthlyTrend->keyBy('month');
+
+            $previousMonth = now()->subMonth()->format('Y-m');
+            $twoMonthsAgo = now()->subMonths(2)->format('Y-m');
+
+            return $monthlyTrend->count() === 6
+                && $months[$previousMonth]['work_minutes'] === 540
+                && $months[$previousMonth]['overtime_minutes'] === 60
+                && $months[$twoMonthsAgo]['work_minutes'] === 480
+                && $months[$twoMonthsAgo]['overtime_minutes'] === 0;
+        });
+    }
+
+    /**
+     * 勤怠レポートの異常件数が正しいことを検証する。
+     */
+    private function assertAnomalies(TestResponse $response): void
+    {
+        $response->assertViewHas('anomalies', [
+            'late_count' => 1,
+            'early_leave_count' => 1,
+            'long_work_count' => 1,
+        ]);
+    }
+
+    /**
+     * 未認証ユーザーは勤怠レポート画面にアクセスできない。
+     */
+    public function test_guest_cannot_access_attendance_report(): void
+    {
+        $response = $this->get('/attendance/report');
+
+        $response->assertRedirect('/login');
+    }
+
+    /**
+     * 認証ユーザーの勤怠統計情報が正しく計算される。
+     */
+    public function test_authenticated_user_can_see_correct_attendance_statistics(): void
+    {
+        $user = User::factory()->create();
+
+        $this->createReportTestRecords($user);
+
+        $response = $this
+            ->actingAs($user)
+            ->get('/attendance/report');
+
+        $response->assertOk();
+
+        $this->assertSummary($response);
+        $this->assertMonthlyTrend($response);
+        $this->assertAnomalies($response);
+    }
+
+    /**
+     * 勤怠記録がないユーザーでもエラーにならず、
+     * 0または空の統計情報が表示される。
+     */
+    public function test_user_without_attendance_records_can_see_empty_report(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->get('/attendance/report');
+
+        $response->assertOk();
+
+        $response->assertViewHas('summary', [
+            'total_work_minutes' => 0,
+            'total_overtime_minutes' => 0,
+            'avg_work_minutes' => 0,
+        ]);
+
+        $response->assertViewHas('monthlyTrend', function ($monthlyTrend) {
+            return $monthlyTrend->count() === 6
+                && $monthlyTrend->every(function (array $month): bool {
+                    return $month['work_minutes'] === 0
+                        && $month['overtime_minutes'] === 0;
+                });
+        });
+
+        $response->assertViewHas('anomalies', [
+            'late_count' => 0,
+            'early_leave_count' => 0,
+            'long_work_count' => 0,
+        ]);
+    }
+}

--- a/tests/Support/AttendanceReportTestHelper.php
+++ b/tests/Support/AttendanceReportTestHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Support;
+
+use App\Models\AttendanceRecord;
+use App\Models\User;
+
+trait AttendanceReportTestHelper
+{
+    /**
+     * 勤怠レポートのテストデータを作成する。
+     */
+    protected function createReportTestRecords(User $user): void
+    {
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->subMonth()->startOfMonth()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->subMonths(2)->startOfMonth()->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '17:00:00',
+        ]);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfMonth()->addDay()->toDateString(),
+            'clock_in' => '09:30:00',
+            'clock_out' => '18:00:00',
+        ]);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfMonth()->addDays(2)->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '17:00:00',
+        ]);
+
+        AttendanceRecord::factory()->create([
+            'user_id' => $user->id,
+            'date' => now()->startOfMonth()->addDays(3)->toDateString(),
+            'clock_in' => '09:00:00',
+            'clock_out' => '20:00:00',
+        ]);
+    }
+}


### PR DESCRIPTION
## 概要

マイ勤怠レポート機能に対するテストを実装し、認証状態に応じたアクセス制御と、勤怠データから算出される統計情報が正しく表示・計算されることを確認する。

## 実装内容

* ゲストのレポートページアクセス制御テストを実装
* 認証ユーザーの統計情報テストを実装
* `summary` の総労働時間・総残業時間・平均労働時間の集計テストを実装
* `monthlyTrend` の月別集計テストを実装
* `anomalies` の遅刻・早退・長時間労働の集計テストを実装
* 勤怠記録が存在しないユーザーのテストを実装
* テストデータ作成処理を `AttendanceReportTestHelper` に分離

## テスト項目

- AttendanceReportTest（3テスト：正常系1・異常系2）

## 対応issue
close #74 