### PR TITLE
fix: マイ勤怠レポートの集計期間を「今月を含む過去6ヶ月」に変更 #84

### DIFF
--- a/app/Services/AttendanceReportService.php
+++ b/app/Services/AttendanceReportService.php
@@ -14,7 +14,7 @@ class AttendanceReportService
     ) {}
 
     /**
-     * 今月と今月を除く過去6か月分の勤怠記録を取得する。
+     * 今月を含む過去6か月分の勤怠記録を取得する。
      *
      * @param  User  $user  対象ユーザー
      * @return Collection<int, AttendanceRecord> 勤怠記録のCollection
@@ -23,7 +23,7 @@ class AttendanceReportService
     {
         $startDate = now()
             ->startOfMonth()
-            ->subMonths(6);
+            ->subMonths(5);
 
         $endDate = now()->endOfMonth();
 
@@ -70,11 +70,9 @@ class AttendanceReportService
     ): array {
         $startDate = now()
             ->startOfMonth()
-            ->subMonths(6);
+            ->subMonths(5);
 
-        $endDate = now()
-            ->startOfMonth()
-            ->subDay();
+        $endDate = now()->endOfMonth();
 
         $targetResults = $dailyResults->filter(
             fn (array $result): bool => Carbon::parse($result['record']->date)->between(
@@ -113,7 +111,7 @@ class AttendanceReportService
     }
 
     /**
-     * 過去6か月分の月次勤怠サマリーを取得する。
+     * 今月を含む過去6か月分の月次勤怠サマリーを取得する。
      *
      * 勤怠記録が存在しない月も0時間として返す。
      *
@@ -126,7 +124,7 @@ class AttendanceReportService
     ): Collection {
         $startMonth = now()
             ->startOfMonth()
-            ->subMonths(6);
+            ->subMonths(5);
 
         return collect(range(0, 5))->map(
             function (int $month) use (

--- a/tests/Feature/Attendance/AttendanceReportTest.php
+++ b/tests/Feature/Attendance/AttendanceReportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Attendance;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -38,18 +38,21 @@ class AttendanceReportTest extends TestCase
         $response->assertOk();
 
         $response->assertViewHas('summary', [
-            'total_work_minutes' => 1020,
-            'total_overtime_minutes' => 60,
-            'avg_work_minutes' => 510,
+            'total_work_minutes' => 2670,
+            'total_overtime_minutes' => 270,
+            'avg_work_minutes' => 534,
         ]);
 
         $response->assertViewHas('monthlyTrend', function ($monthlyTrend) {
             $months = $monthlyTrend->keyBy('month');
 
+            $currentMonth = now()->format('Y-m');
             $previousMonth = now()->subMonth()->format('Y-m');
             $twoMonthsAgo = now()->subMonths(2)->format('Y-m');
 
             return $monthlyTrend->count() === 6
+                && $months[$currentMonth]['work_minutes'] === 1650
+                && $months[$currentMonth]['overtime_minutes'] === 210
                 && $months[$previousMonth]['work_minutes'] === 540
                 && $months[$previousMonth]['overtime_minutes'] === 60
                 && $months[$twoMonthsAgo]['work_minutes'] === 480


### PR DESCRIPTION
# 概要

マイ勤怠レポートの集計期間を、「今月を除く過去6ヶ月」から「今月を含む過去6ヶ月」に変更しました。

これに伴い、基本サマリー・月別サマリー・勤怠記録の取得期間を、今月を含む過去6ヶ月に統一しました。

## 変更内容

- マイ勤怠レポートの勤怠記録取得期間を「今月を含む過去6ヶ月」に変更
- 総労働時間の集計期間を「今月を含む過去6ヶ月」に変更
- 総残業時間の集計期間を「今月を含む過去6ヶ月」に変更
- 平均労働時間の集計期間を「今月を含む過去6ヶ月」に変更
- 月別の労働時間・残業時間を「今月を含む6ヶ月分」で表示するように変更
- 今月の勤怠データが基本サマリー・月別サマリーに含まれるようにテストを修正
- `AttendanceReportTest` を `tests/Feature/Attendance/` 配下へ移動

## 動作確認

- [ ] 一般ユーザーが `/attendance/report` にアクセスできる
- [ ] 未認証ユーザーが `/attendance/report` にアクセスすると `/login` へリダイレクトされる
- [ ] 今月を含む過去6ヶ月の総労働時間が正しく集計される
- [ ] 今月を含む過去6ヶ月の総残業時間が正しく集計される
- [ ] 今月を含む過去6ヶ月の平均労働時間が正しく計算される
- [ ] 今月を含む6ヶ月分の労働時間が月別に表示される
- [ ] 今月を含む6ヶ月分の残業時間が月別に表示される
- [ ] 勤怠データがない月が0として表示される
- [ ] 当月の遅刻・早退・長時間労働の集計に影響がないことを確認
- [ ] `AttendanceReportTest` が通過する

## 対応issue

close #84
