### PR TITLE
feat: マイ勤怠レポート検証用の意図的なダミーデータ投入 #63

### DIFF
--- a/app/Services/AttendanceReportService.php
+++ b/app/Services/AttendanceReportService.php
@@ -23,7 +23,7 @@ class AttendanceReportService
     {
         $startDate = now()
             ->startOfMonth()
-            ->subMonths(6);
+            ->subMonths(5);
 
         $endDate = now()->endOfMonth();
 
@@ -70,11 +70,9 @@ class AttendanceReportService
     ): array {
         $startDate = now()
             ->startOfMonth()
-            ->subMonths(6);
+            ->subMonths(5);
 
-        $endDate = now()
-            ->startOfMonth()
-            ->subDay();
+        $endDate = now()->endOfMonth();
 
         $targetResults = $dailyResults->filter(
             fn (array $result): bool => Carbon::parse($result['record']->date)->between(
@@ -126,7 +124,7 @@ class AttendanceReportService
     ): Collection {
         $startMonth = now()
             ->startOfMonth()
-            ->subMonths(6);
+            ->subMonths(5);
 
         return collect(range(0, 5))->map(
             function (int $month) use (

--- a/database/seeders/AttendanceRecordSeeder.php
+++ b/database/seeders/AttendanceRecordSeeder.php
@@ -17,22 +17,148 @@ class AttendanceRecordSeeder extends Seeder
         $users = User::all();
 
         foreach ($users as $user) {
-            for ($i = 0; $i <= 20; $i++) {
-                $date = Carbon::now()->subDays($i);
-
-                // 土日は除外
-                if ($date->isWeekend()) {
-                    continue;
-                }
-
-                AttendanceRecord::create([
-                    'user_id' => $user->id,
-                    'date' => $date->toDateString(),
-                    'clock_in' => '09:00:00',
-                    'clock_out' => '18:00:00',
-                    'comment' => '通常勤務',
-                ]);
+            if ($user->email === 'user1@example.com') {
+                $this->createUser1Records($user);
+            } else {
+                $this->createNormalRecords($user);
             }
         }
+    }
+
+    /**
+     * user1の検証用ダミーデータを作成する。
+     */
+    private function createUser1Records(User $user): void
+    {
+        // 過去5ヶ月：各月15営業日
+        for ($month = 5; $month >= 1; $month--) {
+            $this->createPastMonthRecords(
+                $user,
+                now()->subMonths($month)
+            );
+        }
+
+        // 今月：17日
+        $this->createCurrentMonthRecords($user);
+    }
+
+    /**
+     * 過去1ヶ月分の通常勤務データを15営業日分作成する。
+     */
+    private function createPastMonthRecords(
+        User $user,
+        Carbon $month
+    ): void {
+        $date = $month->copy()->startOfMonth();
+        $createdDays = 0;
+
+        while ($createdDays < 15) {
+            if ($date->isWeekday()) {
+                $this->createRecord(
+                    $user,
+                    $date,
+                    '09:00:00',
+                    '18:00:00',
+                    '通常勤務'
+                );
+
+                $createdDays++;
+            }
+
+            $date->addDay();
+        }
+    }
+
+    /**
+     * 今月の検証用データを17日分作成する。
+     */
+    private function createCurrentMonthRecords(User $user): void
+    {
+        $date = now()->startOfMonth();
+        $createdDays = 0;
+
+        while ($createdDays < 17) {
+            if ($date->isWeekday()) {
+                if ($createdDays < 10) {
+                    // 通常勤務：10日
+                    $clockIn = '09:00:00';
+                    $clockOut = '18:00:00';
+                    $comment = '通常勤務';
+                } elseif ($createdDays < 13) {
+                    // 残業：3日
+                    $clockIn = '09:00:00';
+                    $clockOut = '20:00:00';
+                    $comment = '残業勤務';
+                } elseif ($createdDays < 15) {
+                    // 遅刻：2日
+                    $clockIn = '09:30:00';
+                    $clockOut = '18:00:00';
+                    $comment = '遅刻勤務';
+                } elseif ($createdDays < 16) {
+                    // 早退：1日
+                    $clockIn = '09:00:00';
+                    $clockOut = '17:00:00';
+                    $comment = '早退勤務';
+                } else {
+                    // 長時間労働：1日
+                    $clockIn = '08:00:00';
+                    $clockOut = '21:00:00';
+                    $comment = '長時間勤務';
+                }
+
+                $this->createRecord(
+                    $user,
+                    $date,
+                    $clockIn,
+                    $clockOut,
+                    $comment
+                );
+
+                $createdDays++;
+            }
+
+            $date->addDay();
+        }
+    }
+
+    /**
+     * 通常ユーザー用のダミーデータを作成する。
+     */
+    private function createNormalRecords(User $user): void
+    {
+        for ($i = 0; $i < 20; $i++) {
+            $date = now()->subDays($i);
+
+            if ($date->isWeekend()) {
+                continue;
+            }
+
+            $this->createRecord(
+                $user,
+                $date,
+                '09:00:00',
+                '18:00:00',
+                '通常勤務'
+            );
+        }
+    }
+
+    /**
+     * 勤怠記録を1件作成する。
+     */
+    private function createRecord(
+        User $user,
+        Carbon $date,
+        string $clockIn,
+        string $clockOut,
+        string $comment
+    ): void {
+        AttendanceRecord::create([
+            'user_id' => $user->id,
+            'date' => $date->toDateString(),
+            'clock_in' => $clockIn,
+            'clock_out' => $clockOut,
+            'comment' => $comment,
+        ]);
     }
 }

--- a/tests/Feature/AttendanceReportTest.php
+++ b/tests/Feature/AttendanceReportTest.php
@@ -38,9 +38,9 @@ class AttendanceReportTest extends TestCase
         $response->assertOk();
 
         $response->assertViewHas('summary', [
-            'total_work_minutes' => 1020,
-            'total_overtime_minutes' => 60,
-            'avg_work_minutes' => 510,
+            'total_work_minutes' => 2670,
+            'total_overtime_minutes' => 270,
+            'avg_work_minutes' => 534,
         ]);
 
         $response->assertViewHas('monthlyTrend', function ($monthlyTrend) {


### PR DESCRIPTION
## 概要

マイ勤怠レポート機能の検証を行うため、意図的なダミーデータを投入できるSeederを実装しました。

## 実装内容

- 検証用ユーザー3名を作成
- 一般ユーザー1に、マイ勤怠レポートの検証に必要なダミー勤怠データを作成
- 勤怠データに12:00〜13:00の休憩データを作成
- 一般ユーザー2・管理者ユーザーにも通常勤務のダミーデータを作成
- マイ勤怠レポートの集計期間を「今月を含む過去6ヶ月」に修正

## 完了条件

- [ ] `sail artisan migrate:fresh --seed` が正常に完了すること
- [ ] 一般ユーザー1の勤怠データが92日分作成されること
- [ ] 一般ユーザー1の休憩データが92件作成されること
- [ ] 過去5ヶ月に各15営業日分のデータが作成されること
- [ ] 今月17日分の検証用データが作成されること
- [ ] マイ勤怠レポートに以下の値が表示されること
  - 総労働時間：744時間
  - 総残業時間：10時間
  - 平均労働時間：8時間5分
  - 遅刻：2回
  - 早退：1回
  - 長時間労働：1回
  -  `AttendanceReportTest` が通過すること

## 対応issue

close #63 
